### PR TITLE
18: Implement EasyMDE Markdown Editor

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "easymde": "^2.20.0",
     "pinia": "^2.3.1",
     "tailwindcss": "^4.1.18",
     "vue": "^3.5.13",

--- a/apps/web/src/modules/admin/components/CategoryForm.vue
+++ b/apps/web/src/modules/admin/components/CategoryForm.vue
@@ -8,6 +8,7 @@ import {
   type UpdateCategoryData,
 } from '../stores/categoriesStore';
 import VsgTreeSelect from '@/shared/components/VsgTreeSelect.vue';
+import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
 
 const props = defineProps<{
   category: Category | null;
@@ -189,18 +190,15 @@ function handleCancel() {
         <!-- Description -->
         <div>
           <label
-            for="description"
             class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
           >
             Beschreibung
           </label>
-          <textarea
-            id="description"
+          <VsgMarkdownEditor
             v-model="description"
-            rows="4"
-            class="form-input-custom w-full px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-vsg-blue-900 text-sm focus:outline-none focus:border-vsg-blue-600 resize-none"
             placeholder="Optionale Beschreibung der Kategorie..."
-          ></textarea>
+            min-height="200px"
+          />
         </div>
 
         <!-- Parent Category -->

--- a/apps/web/src/modules/admin/components/DepartmentForm.vue
+++ b/apps/web/src/modules/admin/components/DepartmentForm.vue
@@ -7,6 +7,7 @@ import {
   type CreateDepartmentData,
   type UpdateDepartmentData,
 } from '../stores/departmentsStore';
+import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
 
 const props = defineProps<{
   department: Department | null;
@@ -173,19 +174,15 @@ function handleCancel() {
         <!-- Long Description -->
         <div>
           <label
-            for="longDescription"
             class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
           >
             Langbeschreibung <span class="text-red-500">*</span>
           </label>
-          <textarea
-            id="longDescription"
+          <VsgMarkdownEditor
             v-model="longDescription"
-            required
-            rows="6"
-            class="form-input-custom w-full px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-vsg-blue-900 text-sm focus:outline-none focus:border-vsg-blue-600 resize-none"
             placeholder="Ausfuhrliche Beschreibung der Abteilung..."
-          ></textarea>
+            min-height="250px"
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/admin/components/NewsForm.vue
+++ b/apps/web/src/modules/admin/components/NewsForm.vue
@@ -10,6 +10,7 @@ import {
 import { useCategoriesStore } from '../stores/categoriesStore';
 import { useTagsStore } from '../stores/tagsStore';
 import { useAuthStore } from '@/modules/auth/stores/authStore';
+import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
 
 const props = defineProps<{
   newsItem: NewsItem | null;
@@ -205,18 +206,15 @@ function toggleTag(tagId: number) {
         <!-- Content -->
         <div>
           <label
-            for="content"
             class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
           >
             Inhalt
           </label>
-          <textarea
-            id="content"
+          <VsgMarkdownEditor
             v-model="content"
-            rows="8"
-            class="form-input-custom w-full px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-vsg-blue-900 text-sm focus:outline-none focus:border-vsg-blue-600 resize-none"
             placeholder="Artikelinhalt..."
-          ></textarea>
+            min-height="300px"
+          />
         </div>
 
         <!-- Author (read-only display) -->

--- a/apps/web/src/shared/components/VsgMarkdownEditor.vue
+++ b/apps/web/src/shared/components/VsgMarkdownEditor.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
+import EasyMDE from 'easymde';
+import 'easymde/dist/easymde.min.css';
+
+interface Props {
+  modelValue: string;
+  placeholder?: string;
+  minHeight?: string;
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  placeholder: '',
+  minHeight: '250px',
+  disabled: false,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+}>();
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+let easyMDE: EasyMDE | null = null;
+
+// Track if we're updating from the editor to prevent feedback loops
+let isUpdatingFromEditor = false;
+
+function initEditor() {
+  if (!textareaRef.value) return;
+
+  easyMDE = new EasyMDE({
+    element: textareaRef.value,
+    initialValue: props.modelValue,
+    placeholder: props.placeholder,
+    minHeight: props.minHeight,
+    spellChecker: false,
+    status: false,
+    sideBySideFullscreen: false,
+    toolbar: [
+      'bold',
+      'italic',
+      'heading',
+      '|',
+      'link',
+      '|',
+      'unordered-list',
+      'ordered-list',
+      '|',
+      'preview',
+      'guide',
+    ],
+  });
+
+  // Set up change handler to emit updates
+  easyMDE.codemirror.on('change', () => {
+    if (!easyMDE) return;
+    isUpdatingFromEditor = true;
+    emit('update:modelValue', easyMDE.value());
+    isUpdatingFromEditor = false;
+  });
+
+  // Apply disabled state if needed
+  if (props.disabled) {
+    easyMDE.codemirror.setOption('readOnly', true);
+  }
+}
+
+function destroyEditor() {
+  if (easyMDE) {
+    easyMDE.toTextArea();
+    easyMDE = null;
+  }
+}
+
+// Watch for external value changes (not from editor)
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (isUpdatingFromEditor || !easyMDE) return;
+    if (easyMDE.value() !== newValue) {
+      easyMDE.value(newValue);
+    }
+  },
+);
+
+// Watch for disabled state changes
+watch(
+  () => props.disabled,
+  (newDisabled) => {
+    if (easyMDE) {
+      easyMDE.codemirror.setOption('readOnly', newDisabled);
+    }
+  },
+);
+
+onMounted(() => {
+  initEditor();
+});
+
+onBeforeUnmount(() => {
+  destroyEditor();
+});
+</script>
+
+<template>
+  <div class="vsg-markdown-editor">
+    <textarea ref="textareaRef"></textarea>
+  </div>
+</template>
+
+<style scoped>
+.vsg-markdown-editor {
+  width: 100%;
+}
+</style>

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -236,3 +236,107 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-vsg-gold-400);
 }
+
+/* EasyMDE Markdown Editor Theme Overrides */
+.EasyMDEContainer {
+  font-family: var(--font-body);
+}
+
+.EasyMDEContainer .CodeMirror {
+  border: 1px solid #d1d5db; /* gray-300 */
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  background: #fff;
+  color: var(--color-vsg-blue-900);
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  padding: 0.5rem;
+}
+
+.EasyMDEContainer .CodeMirror-focused {
+  border-color: var(--color-vsg-blue-600);
+  box-shadow: 0 0 0 3px rgba(252, 211, 77, 0.3);
+}
+
+.EasyMDEContainer .CodeMirror-placeholder {
+  color: #9ca3af; /* gray-400 */
+}
+
+.EasyMDEContainer .editor-toolbar {
+  border: 1px solid #d1d5db; /* gray-300 */
+  border-bottom: none;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+  background: #f9fafb; /* gray-50 */
+  padding: 0.5rem;
+}
+
+.EasyMDEContainer .editor-toolbar button {
+  color: var(--color-vsg-blue-700);
+  border: none;
+  border-radius: 0.25rem;
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.25rem;
+  transition: all 0.2s ease;
+}
+
+.EasyMDEContainer .editor-toolbar button:hover {
+  background: var(--color-vsg-blue-100);
+  color: var(--color-vsg-blue-900);
+}
+
+.EasyMDEContainer .editor-toolbar button.active {
+  background: var(--color-vsg-blue-600);
+  color: #fff;
+}
+
+.EasyMDEContainer .editor-toolbar i.separator {
+  border-left-color: #d1d5db;
+  margin: 0 0.5rem;
+}
+
+.EasyMDEContainer .editor-preview {
+  background: #fff;
+  font-family: var(--font-body);
+  padding: 1rem;
+}
+
+.EasyMDEContainer .editor-preview h1,
+.EasyMDEContainer .editor-preview h2,
+.EasyMDEContainer .editor-preview h3,
+.EasyMDEContainer .editor-preview h4,
+.EasyMDEContainer .editor-preview h5,
+.EasyMDEContainer .editor-preview h6 {
+  color: var(--color-vsg-blue-900);
+  font-family: var(--font-display);
+  margin-bottom: 0.5rem;
+}
+
+.EasyMDEContainer .editor-preview a {
+  color: var(--color-vsg-blue-600);
+}
+
+.EasyMDEContainer .editor-preview a:hover {
+  color: var(--color-vsg-gold-500);
+}
+
+.EasyMDEContainer .editor-preview code {
+  background: #f3f4f6; /* gray-100 */
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+}
+
+.EasyMDEContainer .editor-preview pre {
+  background: #f3f4f6; /* gray-100 */
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+/* Disabled state */
+.EasyMDEContainer .CodeMirror-wrap.CodeMirror-readonly {
+  background: #f9fafb; /* gray-50 */
+  cursor: not-allowed;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6))
+      easymde:
+        specifier: ^2.20.0
+        version: 2.20.0
       pinia:
         specifier: ^2.3.1
         version: 2.3.1(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))
@@ -838,6 +841,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/codemirror@5.60.17':
+    resolution: {integrity: sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -872,6 +878,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/marked@4.3.2':
+    resolution: {integrity: sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -920,6 +929,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
   '@typescript-eslint/eslint-plugin@8.48.0':
     resolution: {integrity: sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==}
@@ -1205,6 +1217,12 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  codemirror-spell-checker@1.1.2:
+    resolution: {integrity: sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==}
+
+  codemirror@5.65.20:
+    resolution: {integrity: sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1356,6 +1374,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  easymde@2.20.0:
+    resolution: {integrity: sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1943,6 +1964,11 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2565,6 +2591,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typo-js@1.3.1:
+    resolution: {integrity: sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -3351,6 +3380,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/codemirror@5.60.17':
+    dependencies:
+      '@types/tern': 0.23.9
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.10.1
@@ -3390,6 +3423,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
       '@types/node': 24.10.1
+
+  '@types/marked@4.3.2': {}
 
   '@types/methods@1.1.4': {}
 
@@ -3456,6 +3491,10 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3848,6 +3887,12 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  codemirror-spell-checker@1.1.2:
+    dependencies:
+      typo-js: 1.3.1
+
+  codemirror@5.65.20: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3971,6 +4016,14 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  easymde@2.20.0:
+    dependencies:
+      '@types/codemirror': 5.60.17
+      '@types/marked': 4.3.2
+      codemirror: 5.65.20
+      codemirror-spell-checker: 1.1.2
+      marked: 4.3.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -4604,6 +4657,8 @@ snapshots:
 
   make-error@1.3.6: {}
 
+  marked@4.3.0: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2:
@@ -5219,6 +5274,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typo-js@1.3.1: {}
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
### Summary

- Add EasyMDE-based Markdown editor component for rich content editing in admin forms
- Replace plain textarea elements with the new editor in CategoryForm, NewsForm, and DepartmentForm
- Style the editor to match the VSG Kugelberg design system (colors, borders, typography)

### Changes

#### New Component

`apps/web/src/shared/components/VsgMarkdownEditor.vue`

- Wraps EasyMDE library with Vue 3 v-model support
- Configurable props: `placeholder`, `minHeight`, `disabled`
- Simplified toolbar: bold, italic, heading, link, lists, preview, guide
- Proper lifecycle management to prevent memory leaks

#### Updated Forms

| Form               | Field            | Min Height |
| ------------------ | ---------------- | ---------- |
| CategoryForm.vue   | Description      | 200px      |
| NewsForm.vue       | Content          | 300px      |
| DepartmentForm.vue | Long Description | 250px      |

#### Styling

Added theme overrides in `style.css` for:

- Editor borders matching form inputs (`border-gray-300`, focus: `border-vsg-blue-600`)
- Toolbar with VSG blue colors and hover states
- Preview pane with proper heading and link colors
- Disabled state styling

### Technical Notes

- EasyMDE includes CodeMirror 5, adding ~100KB to the bundle (acceptable for admin module)
- TypeScript types are included with the package (no separate `@types` needed)
- Editor instance is destroyed via `toTextArea()` on component unmount

### Testing

- [x] Lint passes (pnpm --filter web lint)
- [x] Production build succeeds (pnpm --filter web build)
- [x] Editor initializes with existing values in edit mode
- [x] v-model updates propagate correctly to parent components