### PR TITLE
Add legal pages (Impressum & Datenschutz)

### DIFF
--- a/apps/web/src/modules/default/router/routes.ts
+++ b/apps/web/src/modules/default/router/routes.ts
@@ -1,6 +1,8 @@
 import type { RouteRecordRaw } from 'vue-router';
 import DefaultLayout from '@shared/layouts/DefaultLayout.vue';
 import HomeView from '../views/HomeView.vue';
+import ImpressumView from '../views/ImpressumView.vue';
+import DatenschutzView from '../views/DatenschutzView.vue';
 
 const routes: RouteRecordRaw[] = [
   {
@@ -11,6 +13,16 @@ const routes: RouteRecordRaw[] = [
         path: '',
         name: 'home',
         component: HomeView,
+      },
+      {
+        path: 'impressum',
+        name: 'impressum',
+        component: ImpressumView,
+      },
+      {
+        path: 'datenschutz',
+        name: 'datenschutz',
+        component: DatenschutzView,
       },
     ],
   },

--- a/apps/web/src/modules/default/views/DatenschutzView.vue
+++ b/apps/web/src/modules/default/views/DatenschutzView.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+// Static privacy policy page - no reactive state needed
+</script>
+
+<template>
+  <div class="bg-white">
+    <!-- Header Section -->
+    <section class="bg-vsg-blue-900 pb-20 pt-40">
+      <div class="mx-auto max-w-4xl px-6 text-center">
+        <h1 class="font-display text-5xl tracking-wider text-white md:text-7xl">
+          DATENSCHUTZ
+        </h1>
+        <p class="mt-4 font-body text-lg text-vsg-blue-200">
+          Datenschutzerklärung gemäß DSGVO
+        </p>
+      </div>
+    </section>
+
+    <!-- Content Section -->
+    <section class="py-16">
+      <div class="mx-auto max-w-4xl px-6">
+        <div class="space-y-12">
+          <!-- Verantwortliche Stelle -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              1. Verantwortliche Stelle
+            </h2>
+            <div
+              class="mt-4 space-y-4 font-body text-lg leading-relaxed text-vsg-blue-700"
+            >
+              <p>
+                Verantwortlich für die Datenverarbeitung auf dieser Website ist:
+              </p>
+              <p>
+                VSG Kugelberg e.V.<br />
+                <span class="text-vsg-gold-600">[Adresse einfügen]</span><br />
+                <span class="text-vsg-gold-600">[PLZ Ort einfügen]</span>
+              </p>
+              <p>
+                E-Mail: <span class="text-vsg-gold-600">[E-Mail einfügen]</span
+                ><br />
+                Telefon:
+                <span class="text-vsg-gold-600">[Telefon einfügen]</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Datenerfassung auf der Website -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              2. Datenerfassung auf der Website
+            </h2>
+            <div
+              class="mt-4 space-y-6 font-body text-lg leading-relaxed text-vsg-blue-700"
+            >
+              <!-- Cookies -->
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Cookies
+                </h3>
+                <p>
+                  Unsere Website verwendet Cookies. Cookies sind kleine
+                  Textdateien, die auf Ihrem Endgerät gespeichert werden. Sie
+                  richten keinen Schaden an und enthalten keine Viren. Cookies
+                  dienen dazu, unser Angebot nutzerfreundlicher und effektiver
+                  zu gestalten.
+                </p>
+                <p class="mt-2">
+                  Sie können Ihren Browser so einstellen, dass Sie über das
+                  Setzen von Cookies informiert werden und Cookies nur im
+                  Einzelfall erlauben.
+                </p>
+              </div>
+
+              <!-- Server-Log-Files -->
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Server-Log-Files
+                </h3>
+                <p>
+                  Der Provider der Seiten erhebt und speichert automatisch
+                  Informationen in sogenannten Server-Log-Files, die Ihr Browser
+                  automatisch an uns übermittelt. Dies sind:
+                </p>
+                <ul class="mt-2 list-inside list-disc space-y-1 pl-4">
+                  <li>Browsertyp und Browserversion</li>
+                  <li>Verwendetes Betriebssystem</li>
+                  <li>Referrer URL</li>
+                  <li>Hostname des zugreifenden Rechners</li>
+                  <li>Uhrzeit der Serveranfrage</li>
+                  <li>IP-Adresse</li>
+                </ul>
+                <p class="mt-2">
+                  Eine Zusammenführung dieser Daten mit anderen Datenquellen
+                  wird nicht vorgenommen.
+                </p>
+              </div>
+
+              <!-- Kontaktformular -->
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Kontaktformular
+                </h3>
+                <p>
+                  Wenn Sie uns per Kontaktformular Anfragen zukommen lassen,
+                  werden Ihre Angaben aus dem Anfrageformular inklusive der von
+                  Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung der
+                  Anfrage und für den Fall von Anschlussfragen bei uns
+                  gespeichert. Diese Daten geben wir nicht ohne Ihre
+                  Einwilligung weiter.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Rechte der Betroffenen -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              3. Rechte der Betroffenen
+            </h2>
+            <div
+              class="mt-4 space-y-4 font-body text-lg leading-relaxed text-vsg-blue-700"
+            >
+              <p>
+                Sie haben jederzeit das Recht auf unentgeltliche Auskunft über
+                Ihre gespeicherten personenbezogenen Daten, deren Herkunft und
+                Empfänger und den Zweck der Datenverarbeitung sowie ein Recht
+                auf Berichtigung oder Löschung dieser Daten.
+              </p>
+
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Auskunftsrecht
+                </h3>
+                <p>
+                  Sie haben das Recht, eine Bestätigung darüber zu verlangen, ob
+                  betreffende Daten verarbeitet werden und auf Auskunft über
+                  diese Daten sowie auf weitere Informationen und Kopie der
+                  Daten.
+                </p>
+              </div>
+
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Widerrufsrecht
+                </h3>
+                <p>
+                  Sie haben das Recht, erteilte Einwilligungen jederzeit zu
+                  widerrufen. Durch den Widerruf der Einwilligung wird die
+                  Rechtmäßigkeit der aufgrund der Einwilligung bis zum Widerruf
+                  erfolgten Verarbeitung nicht berührt.
+                </p>
+              </div>
+
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Recht auf Löschung
+                </h3>
+                <p>
+                  Sie haben das Recht, zu verlangen, dass betreffende Daten
+                  unverzüglich gelöscht werden, und wir sind verpflichtet,
+                  personenbezogene Daten unverzüglich zu löschen, sofern einer
+                  der gesetzlichen Gründe zutrifft.
+                </p>
+              </div>
+
+              <div>
+                <h3 class="mb-2 font-display text-xl text-vsg-blue-800">
+                  Beschwerderecht bei der Aufsichtsbehörde
+                </h3>
+                <p>
+                  Sie haben das Recht, sich bei einer
+                  Datenschutz-Aufsichtsbehörde über die Verarbeitung Ihrer
+                  personenbezogenen Daten zu beschweren.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Social Media & Externe Links -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              4. Social Media & Externe Links
+            </h2>
+            <div
+              class="mt-4 space-y-4 font-body text-lg leading-relaxed text-vsg-blue-700"
+            >
+              <p>
+                Unsere Website kann Links zu externen Webseiten Dritter
+                enthalten. Auf die Inhalte dieser Webseiten haben wir keinen
+                Einfluss. Deshalb können wir für diese fremden Inhalte auch
+                keine Gewähr übernehmen.
+              </p>
+              <p>
+                Bei Nutzung von Social-Media-Plugins oder Links zu sozialen
+                Netzwerken können personenbezogene Daten an die jeweiligen
+                Anbieter übertragen werden. Wir weisen darauf hin, dass wir als
+                Anbieter der Seiten keine Kenntnis vom Inhalt der übermittelten
+                Daten sowie deren Nutzung durch die Drittanbieter erhalten.
+              </p>
+              <p>
+                Für weitere Informationen zur Datenverarbeitung durch
+                Drittanbieter beachten Sie bitte die jeweiligen
+                Datenschutzerklärungen der entsprechenden Anbieter.
+              </p>
+            </div>
+          </div>
+
+          <!-- Änderungen -->
+          <div class="border-t border-vsg-blue-100 pt-12">
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              5. Änderungen dieser Datenschutzerklärung
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit
+              sie stets den aktuellen rechtlichen Anforderungen entspricht oder
+              um Änderungen unserer Leistungen umzusetzen. Für Ihren erneuten
+              Besuch gilt dann die neue Datenschutzerklärung.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/apps/web/src/modules/default/views/ImpressumView.vue
+++ b/apps/web/src/modules/default/views/ImpressumView.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+// Static legal notice page - no reactive state needed
+</script>
+
+<template>
+  <div class="bg-white">
+    <!-- Header Section -->
+    <section class="bg-vsg-blue-900 pb-20 pt-40">
+      <div class="mx-auto max-w-4xl px-6 text-center">
+        <h1 class="font-display text-5xl tracking-wider text-white md:text-7xl">
+          IMPRESSUM
+        </h1>
+        <p class="mt-4 font-body text-lg text-vsg-blue-200">
+          Angaben gemäß § 5 TMG
+        </p>
+      </div>
+    </section>
+
+    <!-- Content Section -->
+    <section class="py-16">
+      <div class="mx-auto max-w-4xl px-6">
+        <div class="space-y-12">
+          <!-- Name des Vereins -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Name des Vereins
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              VSG Kugelberg e.V.
+            </p>
+          </div>
+
+          <!-- Vertretungsberechtigte -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Vertretungsberechtigte
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              Vorstand:
+              <span class="text-vsg-gold-600">[Vorstand einfügen]</span>
+            </p>
+          </div>
+
+          <!-- Anschrift -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Anschrift
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              <span class="text-vsg-gold-600">[Adresse einfügen]</span><br />
+              <span class="text-vsg-gold-600">[PLZ Ort einfügen]</span>
+            </p>
+          </div>
+
+          <!-- Kontakt -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Kontakt
+            </h2>
+            <div class="mt-4 space-y-2 font-body text-lg text-vsg-blue-700">
+              <p>
+                E-Mail: <span class="text-vsg-gold-600">[E-Mail einfügen]</span>
+              </p>
+              <p>
+                Telefon:
+                <span class="text-vsg-gold-600">[Telefon einfügen]</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Registergericht -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Registergericht
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              Amtsgericht
+              <span class="text-vsg-gold-600">[Stadt einfügen]</span>
+            </p>
+          </div>
+
+          <!-- Registernummer -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Registernummer
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              VR <span class="text-vsg-gold-600">[Nummer einfügen]</span>
+            </p>
+          </div>
+
+          <!-- Inhaltlich Verantwortlicher -->
+          <div>
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Inhaltlich Verantwortlicher
+            </h2>
+            <p class="mt-4 font-body text-lg leading-relaxed text-vsg-blue-700">
+              gemäß § 55 Abs. 2 RStV:<br />
+              <span class="text-vsg-gold-600">[Name einfügen]</span><br />
+              <span class="text-vsg-gold-600">[Adresse einfügen]</span>
+            </p>
+          </div>
+
+          <!-- Haftungsausschluss -->
+          <div class="border-t border-vsg-blue-100 pt-12">
+            <h2
+              class="font-display text-2xl tracking-wider text-vsg-blue-900 md:text-3xl"
+            >
+              Haftungsausschluss
+            </h2>
+            <div
+              class="mt-4 space-y-4 font-body text-lg leading-relaxed text-vsg-blue-700"
+            >
+              <p>
+                <strong class="text-vsg-blue-900">Haftung für Inhalte:</strong>
+                Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt.
+                Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte
+                können wir jedoch keine Gewähr übernehmen.
+              </p>
+              <p>
+                <strong class="text-vsg-blue-900">Haftung für Links:</strong>
+                Unser Angebot enthält Links zu externen Webseiten Dritter, auf
+                deren Inhalte wir keinen Einfluss haben. Deshalb können wir für
+                diese fremden Inhalte auch keine Gewähr übernehmen.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/apps/web/src/shared/components/VsgFooter.vue
+++ b/apps/web/src/shared/components/VsgFooter.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
 const vereinLinks = [
   { label: 'Geschichte', href: '#' },
   { label: 'Vorstand', href: '#' },
@@ -98,15 +100,15 @@ const vereinLinks = [
           &copy; 2024 VSG Kugelberg e.V. Alle Rechte vorbehalten.
         </span>
         <div class="flex gap-6">
-          <a
-            href="#"
+          <RouterLink
+            to="/impressum"
             class="font-body text-sm font-normal text-vsg-blue-400 transition-colors hover:text-vsg-gold-400"
-            >Impressum</a
+            >Impressum</RouterLink
           >
-          <a
-            href="#"
+          <RouterLink
+            to="/datenschutz"
             class="font-body text-sm font-normal text-vsg-blue-400 transition-colors hover:text-vsg-gold-400"
-            >Datenschutz</a
+            >Datenschutz</RouterLink
           >
         </div>
       </div>


### PR DESCRIPTION
### Summary

Implements mandatory German legal pages for the website: "Impressum" (Legal Notice) and "Datenschutz" (Privacy Policy).

### Changes

- Add `ImpressumView.vue` with placeholder content for required legal information (name, address, contact, registration details)
- Add `DatenschutzView.vue` with privacy policy sections (data collection, user rights, external links)
- Add routes `/impressum` and `/datenschutz` to the default module router
- Update `VsgFooter.vue` to use `<RouterLink>` for SPA navigation to legal pages

### Notes

- Both pages use `DefaultLayout` for consistent navigation
- Placeholder text (marked in gold) indicates where club-specific information needs to be filled in
- Pages follow existing design patterns and are fully responsive