### PR TITLE
17: Add SVG Icon Support for Departments

### DIFF
--- a/apps/api/prisma/migrations/20251228212405_add_department_icon/migration.sql
+++ b/apps/api/prisma/migrations/20251228212405_add_department_icon/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Department" ADD COLUMN     "iconId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Department" ADD CONSTRAINT "Department_iconId_fkey" FOREIGN KEY ("iconId") REFERENCES "Media"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -57,6 +57,8 @@ model Department {
   slug             String   @unique
   shortDescription String
   longDescription  String
+  iconId           Int?
+  icon             Media?   @relation(fields: [iconId], references: [id], onDelete: SetNull)
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
@@ -120,15 +122,16 @@ model ContactPerson {
 }
 
 model Media {
-  id           Int      @id @default(autoincrement())
-  filename     String   @unique
+  id           Int          @id @default(autoincrement())
+  filename     String       @unique
   originalName String
   path         String
   mimetype     String
   size         Int
-  type         String   @default("IMAGE")
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  type         String       @default("IMAGE")
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  departments  Department[]
 
   @@index([type])
   @@index([createdAt])

--- a/apps/api/src/types/department.types.ts
+++ b/apps/api/src/types/department.types.ts
@@ -1,15 +1,22 @@
 import { Department as PrismaDepartment } from '@/lib/prisma.lib';
+import { Media } from './media.types';
 
 export interface CreateDepartmentDto {
   name: string;
   shortDescription: string;
   longDescription: string;
+  iconId?: number;
 }
 
 export interface UpdateDepartmentDto {
   name?: string;
   shortDescription?: string;
   longDescription?: string;
+  iconId?: number | null;
 }
 
 export type Department = PrismaDepartment;
+
+export type DepartmentWithIcon = PrismaDepartment & {
+  icon: Media | null;
+};

--- a/apps/api/src/validators/department.validators.ts
+++ b/apps/api/src/validators/department.validators.ts
@@ -21,6 +21,11 @@ export const createDepartmentValidator = [
     .withMessage('Long description is required')
     .isLength({ min: 20, max: 5000 })
     .withMessage('Long description must be between 20 and 5000 characters'),
+
+  body('iconId')
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage('Icon ID must be a positive integer'),
 ];
 
 export const updateDepartmentValidator = [
@@ -41,6 +46,14 @@ export const updateDepartmentValidator = [
     .trim()
     .isLength({ min: 20, max: 5000 })
     .withMessage('Long description must be between 20 and 5000 characters'),
+
+  body('iconId')
+    .optional({ nullable: true })
+    .custom((value) => {
+      if (value === null) return true;
+      if (Number.isInteger(value) && value >= 1) return true;
+      throw new Error('Icon ID must be a positive integer or null');
+    }),
 ];
 
 export const slugParamValidator = [

--- a/apps/api/tests/helpers.ts
+++ b/apps/api/tests/helpers.ts
@@ -37,14 +37,15 @@ export {
 
 export async function cleanupDatabase() {
   // Delete in correct order: child tables first, then parent tables
+  // Note: department must come before media due to iconId foreign key
   await prisma.$transaction([
     prisma.block.deleteMany(),
     prisma.contactPerson.deleteMany(),
     prisma.event.deleteMany(),
+    prisma.department.deleteMany(),
     prisma.media.deleteMany(),
     prisma.post.deleteMany(),
     prisma.category.deleteMany(),
-    prisma.department.deleteMany(),
     prisma.clubSettings.deleteMany(),
     prisma.user.deleteMany(),
   ]);

--- a/apps/web/src/modules/admin/components/DepartmentForm.vue
+++ b/apps/web/src/modules/admin/components/DepartmentForm.vue
@@ -8,6 +8,7 @@ import {
   type UpdateDepartmentData,
 } from '../stores/departmentsStore';
 import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
+import SvgIconSelector from './SvgIconSelector.vue';
 
 const props = defineProps<{
   department: Department | null;
@@ -20,6 +21,7 @@ const departmentsStore = useDepartmentsStore();
 const name = ref('');
 const shortDescription = ref('');
 const longDescription = ref('');
+const iconId = ref<number | null>(null);
 const error = ref('');
 const isSubmitting = ref(false);
 
@@ -31,6 +33,7 @@ watch(
       name.value = newDepartment.name;
       shortDescription.value = newDepartment.shortDescription;
       longDescription.value = newDepartment.longDescription;
+      iconId.value = newDepartment.iconId;
     }
   },
   { immediate: true },
@@ -57,6 +60,7 @@ async function handleSubmit() {
         name: name.value,
         shortDescription: shortDescription.value,
         longDescription: longDescription.value,
+        iconId: iconId.value,
       };
 
       const result = await departmentsStore.updateDepartment(
@@ -76,6 +80,10 @@ async function handleSubmit() {
         shortDescription: shortDescription.value,
         longDescription: longDescription.value,
       };
+      // Only include iconId if set
+      if (iconId.value !== null) {
+        createData.iconId = iconId.value;
+      }
 
       const result = await departmentsStore.createDepartment(createData);
       if (result) {
@@ -184,6 +192,25 @@ function handleCancel() {
             min-height="250px"
           />
         </div>
+      </div>
+    </div>
+
+    <!-- Icon Section -->
+    <div class="bg-white border border-gray-200 rounded-xl p-6 mb-6 shadow-sm">
+      <h2 class="font-display text-xl tracking-wider text-vsg-blue-900 mb-6">
+        ICON
+      </h2>
+
+      <div>
+        <label
+          class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
+        >
+          Abteilungs-Icon (SVG)
+        </label>
+        <SvgIconSelector
+          v-model="iconId"
+          :current-icon="department?.icon ?? null"
+        />
       </div>
     </div>
 

--- a/apps/web/src/modules/admin/components/SvgIconSelector.vue
+++ b/apps/web/src/modules/admin/components/SvgIconSelector.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useMediaStore, type MediaItem } from '../stores/mediaStore';
+
+const props = defineProps<{
+  modelValue: number | null;
+  currentIcon: MediaItem | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: number | null): void;
+}>();
+
+const mediaStore = useMediaStore();
+
+const showGallery = ref(false);
+const isUploading = ref(false);
+const fileInput = ref<HTMLInputElement | null>(null);
+const previewIcon = ref<MediaItem | null>(null);
+
+// Filter media to show only SVG files
+const svgMedia = computed(() => {
+  return mediaStore.media.filter((item) => item.mimetype === 'image/svg+xml');
+});
+
+// Watch for currentIcon prop to set the preview
+watch(
+  () => props.currentIcon,
+  (icon) => {
+    if (icon) {
+      previewIcon.value = icon;
+    }
+  },
+  { immediate: true },
+);
+
+onMounted(async () => {
+  // Fetch media to populate the gallery
+  if (mediaStore.media.length === 0) {
+    await mediaStore.fetchMedia(1, 100);
+  }
+});
+
+function openGallery() {
+  showGallery.value = true;
+}
+
+function closeGallery() {
+  showGallery.value = false;
+}
+
+function selectIcon(item: MediaItem) {
+  previewIcon.value = item;
+  emit('update:modelValue', item.id);
+  closeGallery();
+}
+
+function clearIcon() {
+  previewIcon.value = null;
+  emit('update:modelValue', null);
+}
+
+function triggerUpload() {
+  fileInput.value?.click();
+}
+
+async function handleFileUpload(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (!input.files || input.files.length === 0) return;
+
+  const file = input.files[0];
+
+  // Validate SVG
+  if (file.type !== 'image/svg+xml') {
+    alert('Bitte nur SVG-Dateien hochladen.');
+    input.value = '';
+    return;
+  }
+
+  isUploading.value = true;
+  try {
+    const result = await mediaStore.uploadMedia(file);
+    if (result) {
+      selectIcon(result);
+    }
+  } finally {
+    isUploading.value = false;
+    input.value = '';
+  }
+}
+</script>
+
+<template>
+  <div>
+    <!-- Current Icon Preview / Placeholder -->
+    <div class="flex items-start gap-4">
+      <!-- Icon Display Area -->
+      <div
+        class="w-24 h-24 border-2 border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden"
+        :class="{ 'border-solid border-vsg-blue-300': previewIcon }"
+      >
+        <img
+          v-if="previewIcon"
+          :src="mediaStore.getMediaUrl(previewIcon)"
+          :alt="previewIcon.originalName"
+          class="w-16 h-16 object-contain"
+        />
+        <svg
+          v-else
+          class="w-8 h-8 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex-1 space-y-2">
+        <p class="font-body text-sm text-gray-600">
+          {{ previewIcon ? previewIcon.originalName : 'Kein Icon ausgewahlt' }}
+        </p>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            @click="openGallery"
+          >
+            Aus Mediathek wahlen
+          </button>
+
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+            :disabled="isUploading"
+            @click="triggerUpload"
+          >
+            {{ isUploading ? 'Hochladen...' : 'SVG hochladen' }}
+          </button>
+
+          <button
+            v-if="previewIcon"
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
+            @click="clearIcon"
+          >
+            Entfernen
+          </button>
+        </div>
+
+        <p class="font-body text-xs text-gray-400">Nur SVG-Dateien erlaubt</p>
+      </div>
+    </div>
+
+    <!-- Hidden File Input -->
+    <input
+      ref="fileInput"
+      type="file"
+      class="hidden"
+      accept=".svg,image/svg+xml"
+      @change="handleFileUpload"
+    />
+
+    <!-- Gallery Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showGallery"
+        class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+        @click.self="closeGallery"
+      >
+        <div
+          class="bg-white rounded-xl shadow-xl max-w-3xl w-full max-h-[80vh] flex flex-col"
+        >
+          <!-- Header -->
+          <div
+            class="flex items-center justify-between px-6 py-4 border-b border-gray-200"
+          >
+            <h3 class="font-display text-lg tracking-wider text-vsg-blue-900">
+              SVG-ICON WAHLEN
+            </h3>
+            <button
+              type="button"
+              class="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+              @click="closeGallery"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Content -->
+          <div class="flex-1 overflow-y-auto p-6">
+            <!-- Empty State -->
+            <div v-if="svgMedia.length === 0" class="text-center py-12">
+              <div
+                class="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4"
+              >
+                <svg
+                  class="w-8 h-8 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <p class="font-body text-gray-500">
+                Keine SVG-Dateien in der Mediathek.
+              </p>
+              <button
+                type="button"
+                class="mt-4 px-4 py-2 text-sm font-body bg-vsg-blue-600 text-white rounded-lg hover:bg-vsg-blue-700 transition-colors"
+                @click="triggerUpload"
+              >
+                SVG hochladen
+              </button>
+            </div>
+
+            <!-- SVG Grid -->
+            <div
+              v-else
+              class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 gap-3"
+            >
+              <button
+                v-for="item in svgMedia"
+                :key="item.id"
+                type="button"
+                class="aspect-square border-2 rounded-lg p-2 flex items-center justify-center transition-all hover:border-vsg-blue-400 hover:bg-vsg-blue-50"
+                :class="[
+                  modelValue === item.id
+                    ? 'border-vsg-blue-600 bg-vsg-blue-50'
+                    : 'border-gray-200 bg-white',
+                ]"
+                :title="item.originalName"
+                @click="selectIcon(item)"
+              >
+                <img
+                  :src="mediaStore.getMediaUrl(item)"
+                  :alt="item.originalName"
+                  class="w-full h-full object-contain"
+                />
+              </button>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div
+            class="px-6 py-4 border-t border-gray-200 flex justify-end gap-3"
+          >
+            <button
+              type="button"
+              class="px-4 py-2 text-sm font-body border border-gray-300 text-gray-600 rounded-lg hover:bg-gray-50 transition-colors"
+              @click="closeGallery"
+            >
+              Abbrechen
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/apps/web/src/modules/admin/stores/departmentsStore.ts
+++ b/apps/web/src/modules/admin/stores/departmentsStore.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
+import type { MediaItem } from './mediaStore';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -9,6 +10,8 @@ export interface Department {
   slug: string;
   shortDescription: string;
   longDescription: string;
+  iconId: number | null;
+  icon: MediaItem | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -17,12 +20,14 @@ export interface CreateDepartmentData {
   name: string;
   shortDescription: string;
   longDescription: string;
+  iconId?: number;
 }
 
 export interface UpdateDepartmentData {
   name?: string;
   shortDescription?: string;
   longDescription?: string;
+  iconId?: number | null;
 }
 
 export const useDepartmentsStore = defineStore('departments', () => {

--- a/apps/web/src/modules/admin/views/DepartmentsListView.vue
+++ b/apps/web/src/modules/admin/views/DepartmentsListView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
 import { useDepartmentsStore } from '../stores/departmentsStore';
+import { useMediaStore } from '../stores/mediaStore';
 
 const departmentsStore = useDepartmentsStore();
+const mediaStore = useMediaStore();
 
 onMounted(() => {
   departmentsStore.fetchDepartments();
@@ -64,6 +66,11 @@ async function handleDelete(slug: string, name: string) {
           <thead>
             <tr class="bg-gray-50 border-b border-gray-200">
               <th
+                class="text-left px-6 py-4 font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase w-16"
+              >
+                Icon
+              </th>
+              <th
                 class="text-left px-6 py-4 font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase"
               >
                 Name
@@ -86,6 +93,17 @@ async function handleDelete(slug: string, name: string) {
               :key="department.id"
               class="hover:bg-gray-50 transition-colors"
             >
+              <td class="px-6 py-4">
+                <div class="w-8 h-8 flex items-center justify-center">
+                  <img
+                    v-if="department.icon"
+                    :src="mediaStore.getMediaUrl(department.icon)"
+                    :alt="department.name"
+                    class="w-6 h-6 object-contain"
+                  />
+                  <span v-else class="text-gray-300">-</span>
+                </div>
+              </td>
               <td class="px-6 py-4">
                 <span class="font-body text-sm text-vsg-blue-900 font-medium">{{
                   department.name

--- a/apps/web/src/modules/default/components/DepartmentsSection.vue
+++ b/apps/web/src/modules/default/components/DepartmentsSection.vue
@@ -3,7 +3,10 @@ import { onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import VsgSectionHeader from '@shared/components/VsgSectionHeader.vue';
 import DepartmentCard from './DepartmentCard.vue';
-import { useDefaultDepartmentsStore } from '../stores/departmentsStore';
+import {
+  useDefaultDepartmentsStore,
+  getMediaUrl,
+} from '../stores/departmentsStore';
 
 const departmentsStore = useDefaultDepartmentsStore();
 const { departments, isLoading, error } = storeToRefs(departmentsStore);
@@ -63,7 +66,18 @@ onMounted(() => {
           :href="`/abteilungen/${department.slug}`"
         >
           <template #icon>
+            <img
+              v-if="department.icon"
+              :src="getMediaUrl(department.icon)"
+              :alt="department.name"
+              class="h-8 w-8 object-contain"
+              style="
+                filter: invert(27%) sepia(51%) saturate(2878%)
+                  hue-rotate(200deg) brightness(89%) contrast(91%);
+              "
+            />
             <svg
+              v-else
               class="h-8 w-8 text-vsg-blue-600"
               fill="currentColor"
               viewBox="0 0 24 24"

--- a/apps/web/src/modules/default/stores/departmentsStore.ts
+++ b/apps/web/src/modules/default/stores/departmentsStore.ts
@@ -3,14 +3,32 @@ import { defineStore } from 'pinia';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
+export interface MediaItem {
+  id: number;
+  filename: string;
+  originalName: string;
+  path: string;
+  mimetype: string;
+  size: number;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Department {
   id: number;
   name: string;
   slug: string;
   shortDescription: string;
   longDescription: string;
+  iconId: number | null;
+  icon: MediaItem | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export function getMediaUrl(item: MediaItem): string {
+  return `${API_BASE_URL}/uploads/${item.filename}`;
 }
 
 export const useDefaultDepartmentsStore = defineStore(


### PR DESCRIPTION
### Summary

This PR adds the ability to assign SVG icons to departments, improving visual recognition across the website.

### Changes

#### Backend changes

- Added `iconId` field to Department model with foreign key relation to Media table (`onDelete: SetNull`)
- Added SVG mimetype validation to ensure only `image/svg+xml` files can be used as icons
- Updated department service to include icon relation in all queries
- Added 9 integration tests covering icon CRUD operations and edge cases

#### Frontend changes

- Created `SvgIconSelector.vue` component with media gallery browsing, direct SVG upload, and preview functionality
- Integrated icon selector into `DepartmentForm.vue` for admin management
- Added icon column to admin department listing view
- Updated public department cards to display icons with blue color styling