### PR TITLE
22: Add department detail views

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "easymde": "^2.20.0",
+    "marked": "^17.0.1",
     "pinia": "^2.3.1",
     "tailwindcss": "^4.1.18",
     "v-calendar": "^3.1.2",

--- a/apps/web/src/modules/admin/components/ThumbnailSelector.vue
+++ b/apps/web/src/modules/admin/components/ThumbnailSelector.vue
@@ -24,7 +24,7 @@ const thumbnailUrl = computed(() => {
   if (props.thumbnail) {
     return mediaStore.getMediaUrl(props.thumbnail);
   }
-  return null;
+  return undefined;
 });
 
 function openMediaLibrary() {

--- a/apps/web/src/modules/default/components/DepartmentsSection.vue
+++ b/apps/web/src/modules/default/components/DepartmentsSection.vue
@@ -63,7 +63,7 @@ onMounted(() => {
           :key="department.id"
           :title="department.name.toUpperCase()"
           :description="department.shortDescription"
-          :href="`/abteilungen/${department.slug}`"
+          :href="`/abteilung/${department.slug}`"
         >
           <template #icon>
             <img

--- a/apps/web/src/modules/default/router/routes.ts
+++ b/apps/web/src/modules/default/router/routes.ts
@@ -4,6 +4,7 @@ import HomeView from '../views/HomeView.vue';
 import ImpressumView from '../views/ImpressumView.vue';
 import DatenschutzView from '../views/DatenschutzView.vue';
 import ContactView from '../views/ContactView.vue';
+import DepartmentDetailView from '../views/DepartmentDetailView.vue';
 import HistoryView from '../views/verein/HistoryView.vue';
 import BoardView from '../views/verein/BoardView.vue';
 import StatutesView from '../views/verein/StatutesView.vue';
@@ -59,6 +60,11 @@ const routes: RouteRecordRaw[] = [
         path: 'verein/sponsoren',
         name: 'verein-sponsoren',
         component: SponsorsView,
+      },
+      {
+        path: 'abteilung/:slug',
+        name: 'department-detail',
+        component: DepartmentDetailView,
       },
     ],
   },

--- a/apps/web/src/modules/default/views/DepartmentDetailView.vue
+++ b/apps/web/src/modules/default/views/DepartmentDetailView.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { watch, onMounted, onUnmounted, watchEffect } from 'vue';
+import { useRoute } from 'vue-router';
+import { storeToRefs } from 'pinia';
+import { RouterLink } from 'vue-router';
+import VsgMarkdownRenderer from '@shared/components/VsgMarkdownRenderer.vue';
+import {
+  useDefaultDepartmentsStore,
+  getMediaUrl,
+} from '../stores/departmentsStore';
+
+const route = useRoute();
+const departmentsStore = useDefaultDepartmentsStore();
+const {
+  currentDepartment,
+  currentDepartmentLoading,
+  currentDepartmentError,
+  currentDepartmentNotFound,
+} = storeToRefs(departmentsStore);
+
+function fetchDepartment() {
+  const slug = route.params.slug as string;
+  if (slug) {
+    departmentsStore.fetchDepartmentBySlug(slug);
+  }
+}
+
+// Fetch on mount
+onMounted(() => {
+  fetchDepartment();
+});
+
+// Watch for route param changes
+watch(
+  () => route.params.slug,
+  () => {
+    fetchDepartment();
+  },
+);
+
+// Set dynamic page title
+watchEffect(() => {
+  if (currentDepartment.value) {
+    document.title = `${currentDepartment.value.name} | VSG Kugelberg`;
+  } else if (currentDepartmentNotFound.value) {
+    document.title = 'Abteilung nicht gefunden | VSG Kugelberg';
+  } else {
+    document.title = 'Abteilung | VSG Kugelberg';
+  }
+});
+
+// Clear state on unmount
+onUnmounted(() => {
+  departmentsStore.clearCurrentDepartment();
+});
+</script>
+
+<template>
+  <div class="bg-white">
+    <!-- Loading State -->
+    <div
+      v-if="currentDepartmentLoading"
+      class="flex min-h-[60vh] items-center justify-center"
+    >
+      <div
+        class="h-12 w-12 animate-spin rounded-full border-4 border-vsg-blue-200 border-t-vsg-blue-600"
+      ></div>
+    </div>
+
+    <!-- Error State -->
+    <div
+      v-else-if="currentDepartmentError"
+      class="flex min-h-[60vh] flex-col items-center justify-center px-6"
+    >
+      <div class="max-w-md text-center">
+        <svg
+          class="mx-auto mb-6 h-16 w-16 text-red-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <h1 class="mb-4 font-display text-2xl text-vsg-blue-900">
+          Fehler beim Laden
+        </h1>
+        <p class="mb-6 text-vsg-blue-700">{{ currentDepartmentError }}</p>
+        <button
+          class="rounded-lg bg-vsg-blue-600 px-6 py-3 font-body text-sm font-medium text-white transition-colors hover:bg-vsg-blue-700"
+          @click="fetchDepartment"
+        >
+          Erneut versuchen
+        </button>
+      </div>
+    </div>
+
+    <!-- Not Found State -->
+    <div
+      v-else-if="currentDepartmentNotFound"
+      class="flex min-h-[60vh] flex-col items-center justify-center px-6"
+    >
+      <div class="max-w-md text-center">
+        <div
+          class="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-vsg-blue-100"
+        >
+          <span class="font-display text-4xl text-vsg-blue-600">404</span>
+        </div>
+        <h1 class="mb-4 font-display text-2xl text-vsg-blue-900">
+          Abteilung nicht gefunden
+        </h1>
+        <p class="mb-6 text-vsg-blue-700">
+          Die angeforderte Abteilung existiert nicht oder wurde entfernt.
+        </p>
+        <RouterLink
+          to="/"
+          class="inline-block rounded-lg bg-vsg-gold-500 px-6 py-3 font-body text-sm font-medium text-vsg-blue-900 transition-colors hover:bg-vsg-gold-400"
+        >
+          Zur Startseite
+        </RouterLink>
+      </div>
+    </div>
+
+    <!-- Department Content -->
+    <template v-else-if="currentDepartment">
+      <!-- Header Section -->
+      <section class="bg-vsg-blue-900 pb-20 pt-40">
+        <div class="mx-auto max-w-4xl px-6 text-center">
+          <!-- Icon -->
+          <div
+            v-if="currentDepartment.icon"
+            class="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-vsg-gold-400/20"
+          >
+            <img
+              :src="getMediaUrl(currentDepartment.icon)"
+              :alt="currentDepartment.name"
+              class="h-12 w-12 object-contain"
+              style="
+                filter: brightness(0) saturate(100%) invert(100%) sepia(0%)
+                  saturate(0%) hue-rotate(0deg) brightness(100%) contrast(100%);
+              "
+            />
+          </div>
+          <div
+            v-else
+            class="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-vsg-gold-400/20"
+          >
+            <svg
+              class="h-12 w-12 text-white"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <circle cx="12" cy="12" r="10" />
+            </svg>
+          </div>
+
+          <!-- Title -->
+          <h1
+            class="font-display text-5xl tracking-wider text-white md:text-7xl"
+          >
+            {{ currentDepartment.name.toUpperCase() }}
+          </h1>
+        </div>
+      </section>
+
+      <!-- Content Section -->
+      <section class="py-16">
+        <div class="mx-auto max-w-4xl px-6">
+          <VsgMarkdownRenderer :content="currentDepartment.longDescription" />
+        </div>
+      </section>
+    </template>
+  </div>
+</template>

--- a/apps/web/src/shared/components/VsgMarkdownRenderer.vue
+++ b/apps/web/src/shared/components/VsgMarkdownRenderer.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { marked } from 'marked';
+
+interface Props {
+  content: string | null | undefined;
+}
+
+const props = defineProps<Props>();
+
+const renderedHtml = computed(() => {
+  if (!props.content) {
+    return '';
+  }
+
+  return marked.parse(props.content, {
+    gfm: true,
+    breaks: true,
+  }) as string;
+});
+</script>
+
+<template>
+  <div v-if="renderedHtml" class="markdown-content" v-html="renderedHtml"></div>
+</template>
+
+<style scoped>
+.markdown-content {
+  font-family: var(--font-body);
+  font-size: 1.125rem;
+  line-height: 1.75;
+  color: var(--color-vsg-blue-700);
+}
+
+.markdown-content :deep(h1) {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  letter-spacing: 0.05em;
+  color: var(--color-vsg-blue-900);
+  margin-top: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.markdown-content :deep(h2) {
+  font-family: var(--font-display);
+  font-size: 1.875rem;
+  letter-spacing: 0.05em;
+  color: var(--color-vsg-blue-900);
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.markdown-content :deep(h3) {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+  color: var(--color-vsg-blue-900);
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.markdown-content :deep(h4) {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  letter-spacing: 0.05em;
+  color: var(--color-vsg-blue-900);
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content :deep(p) {
+  margin-bottom: 1rem;
+  color: var(--color-vsg-blue-700);
+}
+
+.markdown-content :deep(a) {
+  color: var(--color-vsg-blue-600);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.markdown-content :deep(a:hover) {
+  color: var(--color-vsg-gold-500);
+}
+
+.markdown-content :deep(strong) {
+  font-weight: 600;
+  color: var(--color-vsg-blue-900);
+}
+
+.markdown-content :deep(ul) {
+  margin-bottom: 1rem;
+  margin-left: 1.5rem;
+  list-style-type: disc;
+  color: var(--color-vsg-blue-700);
+}
+
+.markdown-content :deep(ol) {
+  margin-bottom: 1rem;
+  margin-left: 1.5rem;
+  list-style-type: decimal;
+  color: var(--color-vsg-blue-700);
+}
+
+.markdown-content :deep(li) {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content :deep(li::marker) {
+  color: var(--color-vsg-gold-500);
+}
+
+.markdown-content :deep(blockquote) {
+  margin: 1rem 0;
+  padding-left: 1rem;
+  border-left: 4px solid var(--color-vsg-gold-500);
+  font-style: italic;
+  color: var(--color-vsg-blue-600);
+}
+
+.markdown-content :deep(code) {
+  background: var(--color-vsg-blue-100);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-family: monospace;
+  font-size: 0.875em;
+  color: var(--color-vsg-blue-800);
+}
+
+.markdown-content :deep(pre) {
+  margin: 1rem 0;
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 0.5rem;
+  background: var(--color-vsg-blue-900);
+}
+
+.markdown-content :deep(pre code) {
+  background: transparent;
+  padding: 0;
+  color: var(--color-vsg-blue-100);
+}
+
+.markdown-content :deep(hr) {
+  margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--color-vsg-blue-200);
+}
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       easymde:
         specifier: ^2.20.0
         version: 2.20.0
+      marked:
+        specifier: ^17.0.1
+        version: 17.0.1
       pinia:
         specifier: ^2.3.1
         version: 2.3.1(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))
@@ -2025,6 +2028,11 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@4.3.0:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
@@ -4808,6 +4816,8 @@ snapshots:
       semver: 7.7.3
 
   make-error@1.3.6: {}
+
+  marked@17.0.1: {}
 
   marked@4.3.0: {}
 


### PR DESCRIPTION
## Summary

- Add `/abteilung/:slug` route with department detail page featuring blue header section and Markdown content rendering
- Update navbar to dynamically fetch and display departments from API in both desktop dropdown and mobile menu
- Create reusable `VsgMarkdownRenderer` component for rendering Markdown content with theme-consistent styling