### PR TITLE
Add MailHog Integration for Email Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mailhog:
+        image: mailhog/mailhog:latest
+        ports:
+          - 1025:1025
+          - 8025:8025
     env:
       PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: 1
       DATABASE_URL: postgresql://user:secret@localhost:5432/database_test?schema=public
       JWT_EXPIRATION: 12h
+      EMAIL_PROVIDER: smtp
+      SMTP_HOST: localhost
+      SMTP_PORT: 1025
+      SMTP_FROM: noreply@vsg-kugelberg.de
+      MAILHOG_API_URL: http://localhost:8025
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,4 @@
+# Database Configuration
 DATABASE_URL="postgresql://user:secret@localhost:5432/database?schema=public"
 
 # JWT Configuration
@@ -10,7 +11,7 @@ NODE_ENV="development"
 # CORS configuration
 # Comma-separated list of allowed origins (e.g. "https://example.com,http://localhost:5173")
 # If not set and NODE_ENV=development, http://localhost:5173 is allowed by default.
-CORS_ORIGINS=""
+CORS_ORIGINS="http://localhost:5173"
 
 # Media Upload Configuration (optional)
 # Directory for uploaded files (default: ./uploads)
@@ -34,6 +35,21 @@ EMAIL_PROVIDER="console"
 # SMTP_USER="your-smtp-username"
 # SMTP_PASS="your-smtp-password"
 # SMTP_FROM="noreply@example.com"
+
+# MailHog Configuration (for development/testing)
+# Start MailHog with: docker compose --profile development up -d mailhog
+# Web UI available at: http://localhost:8025
+# MAILHOG_SMTP_PORT=1025
+# MAILHOG_UI_PORT=8025
+# MAILHOG_API_URL="http://localhost:8025"
+
+# To use MailHog for email testing, set:
+# EMAIL_PROVIDER="smtp"
+# SMTP_HOST="localhost"
+# SMTP_PORT=1025
+# SMTP_USER=""
+# SMTP_PASS=""
+# SMTP_FROM="noreply@vsg-kugelberg.de"
 
 # Redis Configuration (for rate limiting)
 # Full Redis connection URL (takes precedence over individual settings)

--- a/apps/api/tests/helpers/mailhog.ts
+++ b/apps/api/tests/helpers/mailhog.ts
@@ -1,0 +1,151 @@
+/**
+ * MailHog test helper functions for email verification in integration tests.
+ * Uses the MailHog REST API to retrieve and manage captured emails.
+ */
+
+/**
+ * MailHog email address structure
+ */
+export interface MailHogAddress {
+  Mailbox: string;
+  Domain: string;
+  Params: string;
+}
+
+/**
+ * MailHog message content structure
+ */
+export interface MailHogContent {
+  Headers: Record<string, string[]>;
+  Body: string;
+  Size: number;
+  MIME: unknown;
+}
+
+/**
+ * MailHog message structure
+ */
+export interface MailHogMessage {
+  ID: string;
+  From: MailHogAddress;
+  To: MailHogAddress[];
+  Content: MailHogContent;
+  Created: string;
+  MIME: unknown;
+  Raw: {
+    From: string;
+    To: string[];
+    Data: string;
+    Helo: string;
+  };
+}
+
+/**
+ * MailHog API response structure for messages endpoint
+ */
+interface MailHogResponse {
+  total: number;
+  count: number;
+  start: number;
+  items: MailHogMessage[];
+}
+
+const MAILHOG_API_URL = process.env.MAILHOG_API_URL || 'http://localhost:8025';
+
+/**
+ * Fetch all emails from MailHog.
+ * @returns Array of captured email messages
+ * @throws Error if MailHog is not accessible
+ */
+export async function getEmails(): Promise<MailHogMessage[]> {
+  try {
+    const response = await fetch(`${MAILHOG_API_URL}/api/v2/messages`);
+    if (!response.ok) {
+      throw new Error(`MailHog API returned ${response.status}`);
+    }
+    const data: MailHogResponse = await response.json();
+    return data.items;
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new Error(
+        `MailHog is not accessible at ${MAILHOG_API_URL}. ` +
+          'Start it with: docker compose --profile test up -d mailhog',
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetch emails sent to a specific recipient address.
+ * @param email - The recipient email address to filter by
+ * @returns Array of emails sent to the specified address
+ */
+export async function getEmailsTo(email: string): Promise<MailHogMessage[]> {
+  const emails = await getEmails();
+  return emails.filter((msg) =>
+    msg.To.some((to) => `${to.Mailbox}@${to.Domain}` === email),
+  );
+}
+
+/**
+ * Delete all emails from MailHog.
+ * Useful for clearing the mailbox before each test.
+ */
+export async function clearEmails(): Promise<void> {
+  try {
+    const response = await fetch(`${MAILHOG_API_URL}/api/v1/messages`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) {
+      throw new Error(`MailHog API returned ${response.status}`);
+    }
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new Error(
+        `MailHog is not accessible at ${MAILHOG_API_URL}. ` +
+          'Start it with: docker compose --profile test up -d mailhog',
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get the most recently captured email.
+ * @returns The latest email message, or null if no emails exist
+ */
+export async function getLatestEmail(): Promise<MailHogMessage | null> {
+  const emails = await getEmails();
+  return emails.length > 0 ? emails[0] : null;
+}
+
+/**
+ * Get the subject line from a MailHog message.
+ * @param message - The MailHog message
+ * @returns The email subject, or empty string if not found
+ */
+export function getEmailSubject(message: MailHogMessage): string {
+  const subjects = message.Content.Headers['Subject'];
+  return subjects && subjects.length > 0 ? subjects[0] : '';
+}
+
+/**
+ * Get the email body content from a MailHog message.
+ * @param message - The MailHog message
+ * @returns The email body content
+ */
+export function getEmailBody(message: MailHogMessage): string {
+  return message.Content.Body;
+}
+
+/**
+ * Get the recipient email address from a MailHog message.
+ * @param message - The MailHog message
+ * @returns The first recipient email address, or empty string if none
+ */
+export function getEmailRecipient(message: MailHogMessage): string {
+  if (message.To.length === 0) return '';
+  const to = message.To[0];
+  return `${to.Mailbox}@${to.Domain}`;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,14 @@ services:
       - mysql_data:/var/lib/mysql
     profiles: [development]
 
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: mailhog
+    ports:
+      - "${MAILHOG_SMTP_PORT:-1025}:1025"
+      - "${MAILHOG_UI_PORT:-8025}:8025"
+    profiles: [development, test]
+
 volumes:
   postgres_data:
     driver: local


### PR DESCRIPTION
## Summary

Integrates MailHog as a local SMTP server for development and testing environments. This enables programmatic email verification in tests while preventing real emails from being sent during test runs.

## Changes

- Add MailHog Docker service with `development` and `test` profiles
- Make SMTP authentication optional in `SmtpEmailService` to support MailHog
- Create MailHog test helper functions (`getEmails`, `getEmailsTo`, `clearEmails`, `getLatestEmail`)
- Configure test environment to use MailHog for email capture
- Add 5 new email verification tests for password reset functionality
- Add MailHog service to GitHub Actions CI workflow

## Files Changed

| File | Description |
|------|-------------|
| `docker-compose.yml` | Added MailHog service |
| `apps/api/.env.example` | Added MailHog configuration variables |
| `apps/api/src/services/email.service.ts` | Made SMTP auth optional |
| `apps/api/tests/helpers/mailhog.ts` | New MailHog API helpers |
| `apps/api/tests/setup.ts` | Configure tests to use MailHog |
| `apps/api/tests/integration/password-reset.test.ts` | Added email verification tests |
| `.github/workflows/ci.yml` | Added MailHog CI service |

## Testing

- All 403 tests pass (including 5 new email verification tests)
- Lint and format checks pass
- CI pipeline passes

## Usage

```bash
# Start MailHog for local development
docker compose --profile development up -d mailhog

# Access MailHog Web UI
open http://localhost:8025
```
