### PR TITLE
Add profile image support for contact persons

### DIFF
--- a/apps/api/prisma/migrations/20251230174151_add_contact_person_profile_image/migration.sql
+++ b/apps/api/prisma/migrations/20251230174151_add_contact_person_profile_image/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ContactPerson" ADD COLUMN     "profileImageId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ContactPerson" ADD CONSTRAINT "ContactPerson_profileImageId_fkey" FOREIGN KEY ("profileImageId") REFERENCES "Media"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -125,29 +125,32 @@ model Event {
 }
 
 model ContactPerson {
-  id        Int      @id @default(autoincrement())
-  firstName String
-  lastName  String
-  type      String
-  email     String?
-  address   String?
-  phone     String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             Int      @id @default(autoincrement())
+  firstName      String
+  lastName       String
+  type           String
+  email          String?
+  address        String?
+  phone          String
+  profileImageId Int?
+  profileImage   Media?   @relation(fields: [profileImageId], references: [id], onDelete: SetNull)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 }
 
 model Media {
-  id           Int          @id @default(autoincrement())
-  filename     String       @unique
-  originalName String
-  path         String
-  mimetype     String
-  size         Int
-  type         String       @default("IMAGE")
-  createdAt    DateTime     @default(now())
-  updatedAt    DateTime     @updatedAt
-  departments  Department[]
-  posts        Post[]
+  id             Int             @id @default(autoincrement())
+  filename       String          @unique
+  originalName   String
+  path           String
+  mimetype       String
+  size           Int
+  type           String          @default("IMAGE")
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  departments    Department[]
+  posts          Post[]
+  contactPersons ContactPerson[]
 
   @@index([type])
   @@index([createdAt])

--- a/apps/api/src/types/contact-person.types.ts
+++ b/apps/api/src/types/contact-person.types.ts
@@ -1,4 +1,4 @@
-import { ContactPerson as PrismaContactPerson } from '@/lib/prisma.lib';
+import { ContactPerson as PrismaContactPerson, Prisma } from '@/lib/prisma.lib';
 
 export interface CreateContactPersonDto {
   firstName: string;
@@ -7,6 +7,7 @@ export interface CreateContactPersonDto {
   email?: string;
   address?: string;
   phone: string;
+  profileImageId?: number;
 }
 
 export interface UpdateContactPersonDto {
@@ -16,6 +17,11 @@ export interface UpdateContactPersonDto {
   email?: string;
   address?: string;
   phone?: string;
+  profileImageId?: number | null;
 }
 
 export type ContactPerson = PrismaContactPerson;
+
+export type ContactPersonWithImage = Prisma.ContactPersonGetPayload<{
+  include: { profileImage: true };
+}>;

--- a/apps/api/src/validators/contact-person.validators.ts
+++ b/apps/api/src/validators/contact-person.validators.ts
@@ -35,6 +35,11 @@ export const createContactPersonValidator = [
     .withMessage('Address must be at most 500 characters'),
 
   body('phone').trim().notEmpty().withMessage('Phone is required'),
+
+  body('profileImageId')
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage('Profile image ID must be a positive integer'),
 ];
 
 export const updateContactPersonValidator = [
@@ -73,6 +78,14 @@ export const updateContactPersonValidator = [
     .trim()
     .notEmpty()
     .withMessage('Phone cannot be empty'),
+
+  body('profileImageId')
+    .optional({ nullable: true })
+    .custom((value) => {
+      if (value === null) return true;
+      if (Number.isInteger(value) && value >= 1) return true;
+      throw new Error('Profile image ID must be a positive integer or null');
+    }),
 ];
 
 export const idParamValidator = [

--- a/apps/web/src/modules/admin/components/ContactPersonForm.vue
+++ b/apps/web/src/modules/admin/components/ContactPersonForm.vue
@@ -7,6 +7,7 @@ import {
   type CreateContactPersonData,
   type UpdateContactPersonData,
 } from '../stores/contactPersonsStore';
+import ProfileImageSelector from './ProfileImageSelector.vue';
 
 const props = defineProps<{
   contactPerson: ContactPerson | null;
@@ -22,6 +23,7 @@ const type = ref('');
 const email = ref('');
 const address = ref('');
 const phone = ref('');
+const profileImageId = ref<number | null>(null);
 const error = ref('');
 const isSubmitting = ref(false);
 
@@ -36,6 +38,7 @@ watch(
       email.value = newContactPerson.email || '';
       address.value = newContactPerson.address || '';
       phone.value = newContactPerson.phone;
+      profileImageId.value = newContactPerson.profileImageId;
     }
   },
   { immediate: true },
@@ -66,6 +69,7 @@ async function handleSubmit() {
         email: email.value || undefined,
         address: address.value || undefined,
         phone: phone.value,
+        profileImageId: profileImageId.value,
       };
 
       const result = await contactPersonsStore.updateContactPerson(
@@ -89,6 +93,10 @@ async function handleSubmit() {
         address: address.value || undefined,
         phone: phone.value,
       };
+      // Only include profileImageId if set
+      if (profileImageId.value !== null) {
+        createData.profileImageId = profileImageId.value;
+      }
 
       const result = await contactPersonsStore.createContactPerson(createData);
       if (result) {
@@ -257,6 +265,25 @@ function handleCancel() {
             placeholder="z.B. Musterstraße 1, 12345 Musterstadt"
           ></textarea>
         </div>
+      </div>
+    </div>
+
+    <!-- Profile Image Section -->
+    <div class="bg-white border border-gray-200 rounded-xl p-6 mb-6 shadow-sm">
+      <h2 class="font-display text-xl tracking-wider text-vsg-blue-900 mb-6">
+        PROFILBILD
+      </h2>
+
+      <div>
+        <label
+          class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
+        >
+          Profilbild
+        </label>
+        <ProfileImageSelector
+          v-model="profileImageId"
+          :current-image="contactPerson?.profileImage ?? null"
+        />
       </div>
     </div>
 

--- a/apps/web/src/modules/admin/components/ProfileImageSelector.vue
+++ b/apps/web/src/modules/admin/components/ProfileImageSelector.vue
@@ -1,0 +1,293 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useMediaStore, type MediaItem } from '../stores/mediaStore';
+
+const props = defineProps<{
+  modelValue: number | null;
+  currentImage: MediaItem | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: number | null): void;
+}>();
+
+const mediaStore = useMediaStore();
+
+const showGallery = ref(false);
+const isUploading = ref(false);
+const fileInput = ref<HTMLInputElement | null>(null);
+const previewImage = ref<MediaItem | null>(null);
+
+const ALLOWED_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+// Filter media to show only allowed image types (JPEG, PNG, WebP)
+const imageMedia = computed(() => {
+  return mediaStore.media.filter((item) =>
+    ALLOWED_MIMETYPES.includes(item.mimetype),
+  );
+});
+
+// Watch for currentImage prop to set the preview
+watch(
+  () => props.currentImage,
+  (image) => {
+    if (image) {
+      previewImage.value = image;
+    }
+  },
+  { immediate: true },
+);
+
+onMounted(async () => {
+  // Fetch media to populate the gallery
+  if (mediaStore.media.length === 0) {
+    await mediaStore.fetchMedia(1, 100);
+  }
+});
+
+function openGallery() {
+  showGallery.value = true;
+}
+
+function closeGallery() {
+  showGallery.value = false;
+}
+
+function selectImage(item: MediaItem) {
+  previewImage.value = item;
+  emit('update:modelValue', item.id);
+  closeGallery();
+}
+
+function clearImage() {
+  previewImage.value = null;
+  emit('update:modelValue', null);
+}
+
+function triggerUpload() {
+  fileInput.value?.click();
+}
+
+async function handleFileUpload(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (!input.files || input.files.length === 0) return;
+
+  const file = input.files[0];
+
+  // Validate image type
+  if (!ALLOWED_MIMETYPES.includes(file.type)) {
+    alert('Bitte nur JPEG, PNG oder WebP Bilder hochladen.');
+    input.value = '';
+    return;
+  }
+
+  isUploading.value = true;
+  try {
+    const result = await mediaStore.uploadMedia(file);
+    if (result) {
+      selectImage(result);
+    }
+  } finally {
+    isUploading.value = false;
+    input.value = '';
+  }
+}
+</script>
+
+<template>
+  <div>
+    <!-- Current Image Preview / Placeholder -->
+    <div class="flex items-start gap-4">
+      <!-- Image Display Area (Circular for profile images) -->
+      <div
+        class="w-32 h-32 border-2 border-dashed border-gray-300 rounded-full flex items-center justify-center bg-gray-50 overflow-hidden"
+        :class="{ 'border-solid border-vsg-blue-300': previewImage }"
+      >
+        <img
+          v-if="previewImage"
+          :src="mediaStore.getMediaUrl(previewImage)"
+          :alt="previewImage.originalName"
+          class="w-full h-full object-cover"
+        />
+        <svg
+          v-else
+          class="w-12 h-12 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </svg>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex-1 space-y-2">
+        <p class="font-body text-sm text-gray-600">
+          {{
+            previewImage ? previewImage.originalName : 'Kein Bild ausgewahlt'
+          }}
+        </p>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            @click="openGallery"
+          >
+            Aus Mediathek wahlen
+          </button>
+
+          <button
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+            :disabled="isUploading"
+            @click="triggerUpload"
+          >
+            {{ isUploading ? 'Hochladen...' : 'Bild hochladen' }}
+          </button>
+
+          <button
+            v-if="previewImage"
+            type="button"
+            class="px-3 py-1.5 text-xs font-body text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
+            @click="clearImage"
+          >
+            Entfernen
+          </button>
+        </div>
+
+        <p class="font-body text-xs text-gray-400">
+          Erlaubte Formate: JPEG, PNG, WebP
+        </p>
+      </div>
+    </div>
+
+    <!-- Hidden File Input -->
+    <input
+      ref="fileInput"
+      type="file"
+      class="hidden"
+      accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+      @change="handleFileUpload"
+    />
+
+    <!-- Gallery Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showGallery"
+        class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+        @click.self="closeGallery"
+      >
+        <div
+          class="bg-white rounded-xl shadow-xl max-w-3xl w-full max-h-[80vh] flex flex-col"
+        >
+          <!-- Header -->
+          <div
+            class="flex items-center justify-between px-6 py-4 border-b border-gray-200"
+          >
+            <h3 class="font-display text-lg tracking-wider text-vsg-blue-900">
+              PROFILBILD WAHLEN
+            </h3>
+            <button
+              type="button"
+              class="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+              @click="closeGallery"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Content -->
+          <div class="flex-1 overflow-y-auto p-6">
+            <!-- Empty State -->
+            <div v-if="imageMedia.length === 0" class="text-center py-12">
+              <div
+                class="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4"
+              >
+                <svg
+                  class="w-8 h-8 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <p class="font-body text-gray-500">
+                Keine passenden Bilder in der Mediathek.
+              </p>
+              <button
+                type="button"
+                class="mt-4 px-4 py-2 text-sm font-body bg-vsg-blue-600 text-white rounded-lg hover:bg-vsg-blue-700 transition-colors"
+                @click="triggerUpload"
+              >
+                Bild hochladen
+              </button>
+            </div>
+
+            <!-- Image Grid -->
+            <div
+              v-else
+              class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3"
+            >
+              <button
+                v-for="item in imageMedia"
+                :key="item.id"
+                type="button"
+                class="aspect-square border-2 rounded-lg overflow-hidden transition-all hover:border-vsg-blue-400 hover:ring-2 hover:ring-vsg-blue-100"
+                :class="[
+                  modelValue === item.id
+                    ? 'border-vsg-blue-600 ring-2 ring-vsg-blue-100'
+                    : 'border-gray-200',
+                ]"
+                :title="item.originalName"
+                @click="selectImage(item)"
+              >
+                <img
+                  :src="mediaStore.getMediaUrl(item)"
+                  :alt="item.originalName"
+                  class="w-full h-full object-cover"
+                />
+              </button>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div
+            class="px-6 py-4 border-t border-gray-200 flex justify-end gap-3"
+          >
+            <button
+              type="button"
+              class="px-4 py-2 text-sm font-body border border-gray-300 text-gray-600 rounded-lg hover:bg-gray-50 transition-colors"
+              @click="closeGallery"
+            >
+              Abbrechen
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/apps/web/src/modules/admin/stores/contactPersonsStore.ts
+++ b/apps/web/src/modules/admin/stores/contactPersonsStore.ts
@@ -3,6 +3,18 @@ import { defineStore } from 'pinia';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
+export interface Media {
+  id: number;
+  filename: string;
+  originalName: string;
+  path: string;
+  mimetype: string;
+  size: number;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ContactPerson {
   id: number;
   firstName: string;
@@ -11,6 +23,8 @@ export interface ContactPerson {
   email: string | null;
   address: string | null;
   phone: string;
+  profileImageId: number | null;
+  profileImage: Media | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -22,6 +36,7 @@ export interface CreateContactPersonData {
   email?: string;
   address?: string;
   phone: string;
+  profileImageId?: number;
 }
 
 export interface UpdateContactPersonData {
@@ -31,6 +46,7 @@ export interface UpdateContactPersonData {
   email?: string;
   address?: string;
   phone?: string;
+  profileImageId?: number | null;
 }
 
 export const useContactPersonsStore = defineStore('contactPersons', () => {

--- a/apps/web/src/modules/default/stores/contactPersonsStore.ts
+++ b/apps/web/src/modules/default/stores/contactPersonsStore.ts
@@ -3,6 +3,18 @@ import { defineStore } from 'pinia';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
+export interface Media {
+  id: number;
+  filename: string;
+  originalName: string;
+  path: string;
+  mimetype: string;
+  size: number;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ContactPerson {
   id: number;
   firstName: string;
@@ -11,6 +23,8 @@ export interface ContactPerson {
   email: string | null;
   address: string | null;
   phone: string;
+  profileImageId: number | null;
+  profileImage: Media | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/web/src/modules/default/views/ContactView.vue
+++ b/apps/web/src/modules/default/views/ContactView.vue
@@ -26,6 +26,18 @@ onMounted(() => {
 function formatOptionLabel(cp: ContactPerson): string {
   return `${cp.type}: ${cp.firstName} ${cp.lastName}`;
 }
+
+function getInitials(cp: ContactPerson): string {
+  const firstInitial = cp.firstName.charAt(0).toUpperCase();
+  const lastInitial = cp.lastName.charAt(0).toUpperCase();
+  return `${firstInitial}${lastInitial}`;
+}
+
+function getProfileImageUrl(cp: ContactPerson): string | null {
+  if (!cp.profileImage) return null;
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+  return `${apiBaseUrl}/uploads/${cp.profileImage.filename}`;
+}
 </script>
 
 <template>
@@ -117,19 +129,42 @@ function formatOptionLabel(cp: ContactPerson): string {
               v-if="selectedContactPerson"
               class="bg-vsg-blue-50 border border-vsg-blue-100 rounded-2xl p-8"
             >
-              <!-- Name and Role -->
+              <!-- Profile Image and Name/Role Header -->
               <div class="mb-6 pb-6 border-b border-vsg-blue-200">
-                <h2
-                  class="font-display text-2xl tracking-wider text-vsg-blue-900"
-                >
-                  {{ selectedContactPerson.firstName }}
-                  {{ selectedContactPerson.lastName }}
-                </h2>
-                <span
-                  class="inline-block mt-2 px-3 py-1 bg-vsg-gold-400 text-vsg-blue-900 text-sm font-body rounded-full"
-                >
-                  {{ selectedContactPerson.type }}
-                </span>
+                <div class="flex items-center gap-6">
+                  <!-- Profile Image or Initials Fallback -->
+                  <div
+                    class="flex-shrink-0 w-32 h-32 rounded-full overflow-hidden bg-vsg-blue-100 flex items-center justify-center"
+                  >
+                    <img
+                      v-if="selectedContactPerson.profileImage"
+                      :src="getProfileImageUrl(selectedContactPerson)!"
+                      :alt="`Profilbild von ${selectedContactPerson.firstName} ${selectedContactPerson.lastName}`"
+                      class="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                    <span
+                      v-else
+                      class="text-3xl font-display text-vsg-blue-400"
+                    >
+                      {{ getInitials(selectedContactPerson) }}
+                    </span>
+                  </div>
+                  <!-- Name and Role -->
+                  <div>
+                    <h2
+                      class="font-display text-2xl tracking-wider text-vsg-blue-900"
+                    >
+                      {{ selectedContactPerson.firstName }}
+                      {{ selectedContactPerson.lastName }}
+                    </h2>
+                    <span
+                      class="inline-block mt-2 px-3 py-1 bg-vsg-gold-400 text-vsg-blue-900 text-sm font-body rounded-full"
+                    >
+                      {{ selectedContactPerson.type }}
+                    </span>
+                  </div>
+                </div>
               </div>
 
               <!-- Contact Information -->


### PR DESCRIPTION
## Summary

- Add optional profile image field to contact persons with support for JPEG, PNG, and WebP formats
- Display circular profile images on public contact page with initials fallback when no image is set
- Add `ProfileImageSelector` component in admin form for browsing media library or uploading new images
## Changes
### Backend

- Added `profileImageId` field and `profileImage` relation to ContactPerson model
- Added validation to ensure only valid image mimetypes (JPEG/PNG/WebP) can be used
- Updated all contact person endpoints to include profile image data
- Added 16 new integration tests covering profile image functionality
### Frontend

- Created `ProfileImageSelector.vue` component based on existing SvgIconSelector pattern
- Updated `ContactPersonForm.vue` to allow selecting/removing profile images
- Updated `ContactView.vue` to display profile images with initials fallback
### Database

- Added migration `20251230174151_add_contact_person_profile_image`
- ON DELETE SET NULL cascade - deleting media sets profileImageId to NULL