### PR TITLE
Add password visibility toggle to all password inputs

### DIFF
--- a/apps/web/src/modules/admin/components/UserForm.vue
+++ b/apps/web/src/modules/admin/components/UserForm.vue
@@ -7,6 +7,7 @@ import {
   type CreateUserData,
   type UpdateUserData,
 } from '../stores/usersStore';
+import VsgPasswordInput from '@shared/components/VsgPasswordInput.vue';
 
 const props = defineProps<{
   user: User | null;
@@ -199,42 +200,30 @@ function handleCancel() {
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <!-- Password -->
-        <div>
-          <label
-            for="password"
-            class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
-          >
-            {{ isEditMode ? 'Neues Passwort' : 'Passwort' }}
-            <span v-if="!isEditMode" class="text-red-500">*</span>
-          </label>
-          <input
-            id="password"
-            v-model="password"
-            type="password"
-            :required="!isEditMode"
-            class="form-input-custom w-full px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-vsg-blue-900 placeholder-gray-400 text-sm focus:outline-none focus:border-vsg-blue-600"
-            placeholder="********"
-          />
-        </div>
+        <VsgPasswordInput
+          id="password"
+          v-model="password"
+          :label="isEditMode ? 'Neues Passwort' : 'Passwort'"
+          :required="!isEditMode"
+          variant="admin"
+        >
+          <template v-if="!isEditMode" #label-suffix>
+            <span class="text-red-500">*</span>
+          </template>
+        </VsgPasswordInput>
 
         <!-- Confirm Password -->
-        <div>
-          <label
-            for="confirmPassword"
-            class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
-          >
-            Passwort bestatigen
-            <span v-if="!isEditMode" class="text-red-500">*</span>
-          </label>
-          <input
-            id="confirmPassword"
-            v-model="confirmPassword"
-            type="password"
-            :required="!isEditMode"
-            class="form-input-custom w-full px-4 py-2.5 bg-white border border-gray-300 rounded-lg text-vsg-blue-900 placeholder-gray-400 text-sm focus:outline-none focus:border-vsg-blue-600"
-            placeholder="********"
-          />
-        </div>
+        <VsgPasswordInput
+          id="confirmPassword"
+          v-model="confirmPassword"
+          label="Passwort bestatigen"
+          :required="!isEditMode"
+          variant="admin"
+        >
+          <template v-if="!isEditMode" #label-suffix>
+            <span class="text-red-500">*</span>
+          </template>
+        </VsgPasswordInput>
       </div>
 
       <!-- Password Error -->

--- a/apps/web/src/modules/auth/components/LoginForm.vue
+++ b/apps/web/src/modules/auth/components/LoginForm.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import { useRouter, RouterLink } from 'vue-router';
 import { useAuthStore } from '../stores/authStore';
+import VsgPasswordInput from '@shared/components/VsgPasswordInput.vue';
 
 const username = ref('');
 const password = ref('');
@@ -59,19 +60,12 @@ async function handleSubmit() {
 
     <!-- Password Input -->
     <div class="animate-slide-up delay-400">
-      <label
-        for="password"
-        class="block font-body font-normal text-sm tracking-wider text-vsg-gold-400 uppercase mb-2"
-      >
-        Passwort
-      </label>
-      <input
+      <VsgPasswordInput
         id="password"
         v-model="password"
-        type="password"
+        label="Passwort"
         required
-        class="form-input-custom w-full px-4 py-3 bg-vsg-blue-800/50 border border-vsg-gold-400/30 rounded-lg text-white placeholder-vsg-blue-300 focus:outline-none focus:border-vsg-gold-400"
-        placeholder="********"
+        variant="auth"
       />
       <div class="mt-2 text-right">
         <RouterLink

--- a/apps/web/src/modules/auth/components/ResetPasswordForm.vue
+++ b/apps/web/src/modules/auth/components/ResetPasswordForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useAuthStore } from '../stores/authStore';
+import VsgPasswordInput from '@shared/components/VsgPasswordInput.vue';
 
 const props = defineProps<{
   token: string;
@@ -100,20 +101,13 @@ async function handleSubmit() {
 
     <!-- New Password Input -->
     <div class="animate-slide-up delay-300">
-      <label
-        for="password"
-        class="block font-body font-normal text-sm tracking-wider text-vsg-gold-400 uppercase mb-2"
-      >
-        Neues Passwort
-      </label>
-      <input
+      <VsgPasswordInput
         id="password"
         v-model="password"
-        type="password"
+        label="Neues Passwort"
         required
-        minlength="8"
-        class="form-input-custom w-full px-4 py-3 bg-vsg-blue-800/50 border border-vsg-gold-400/30 rounded-lg text-white placeholder-vsg-blue-300 focus:outline-none focus:border-vsg-gold-400"
-        placeholder="********"
+        :minlength="8"
+        variant="auth"
       />
       <p class="mt-1 text-xs text-vsg-blue-300">
         Min. 8 Zeichen, Gross-/Kleinbuchstaben und Zahl
@@ -122,20 +116,13 @@ async function handleSubmit() {
 
     <!-- Confirm Password Input -->
     <div class="animate-slide-up delay-400">
-      <label
-        for="confirmPassword"
-        class="block font-body font-normal text-sm tracking-wider text-vsg-gold-400 uppercase mb-2"
-      >
-        Passwort bestaetigen
-      </label>
-      <input
+      <VsgPasswordInput
         id="confirmPassword"
         v-model="confirmPassword"
-        type="password"
+        label="Passwort bestaetigen"
         required
-        minlength="8"
-        class="form-input-custom w-full px-4 py-3 bg-vsg-blue-800/50 border border-vsg-gold-400/30 rounded-lg text-white placeholder-vsg-blue-300 focus:outline-none focus:border-vsg-gold-400"
-        placeholder="********"
+        :minlength="8"
+        variant="auth"
       />
     </div>
 

--- a/apps/web/src/shared/components/VsgPasswordInput.vue
+++ b/apps/web/src/shared/components/VsgPasswordInput.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+
+type Variant = 'auth' | 'admin';
+
+interface Props {
+  id: string;
+  modelValue: string;
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+  minlength?: number;
+  variant?: Variant;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  label: undefined,
+  placeholder: '********',
+  required: false,
+  minlength: undefined,
+  variant: 'auth',
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+}>();
+
+const isVisible = ref(false);
+
+const inputType = computed(() => (isVisible.value ? 'text' : 'password'));
+
+const ariaLabel = computed(() =>
+  isVisible.value ? 'Passwort verbergen' : 'Passwort anzeigen',
+);
+
+function toggleVisibility() {
+  isVisible.value = !isVisible.value;
+}
+
+function handleInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  emit('update:modelValue', target.value);
+}
+
+// Styling classes based on variant
+const labelClasses = computed(() => {
+  const base =
+    'block font-body font-normal text-sm tracking-wider uppercase mb-2';
+  return props.variant === 'auth'
+    ? `${base} text-vsg-gold-400`
+    : `${base} text-vsg-blue-600 text-xs`;
+});
+
+const inputClasses = computed(() => {
+  const base =
+    'form-input-custom w-full px-4 py-3 rounded-lg focus:outline-none pr-12';
+  return props.variant === 'auth'
+    ? `${base} bg-vsg-blue-800/50 border border-vsg-gold-400/30 text-white placeholder-vsg-blue-300 focus:border-vsg-gold-400`
+    : `${base} bg-white border border-gray-300 text-vsg-blue-900 placeholder-gray-400 text-sm py-2.5 focus:border-vsg-blue-600`;
+});
+
+const toggleClasses = computed(() => {
+  const base =
+    'absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded transition-colors focus:outline-none focus:ring-2';
+  return props.variant === 'auth'
+    ? `${base} text-vsg-gold-400/70 hover:text-vsg-gold-400 focus:ring-vsg-gold-400/50`
+    : `${base} text-gray-400 hover:text-gray-600 focus:ring-vsg-blue-400/50`;
+});
+</script>
+
+<template>
+  <div>
+    <label v-if="label" :for="id" :class="labelClasses">
+      {{ label }}
+      <slot name="label-suffix" />
+    </label>
+    <div class="relative">
+      <input
+        :id="id"
+        :type="inputType"
+        :value="modelValue"
+        :required="required"
+        :minlength="minlength"
+        :placeholder="placeholder"
+        :class="inputClasses"
+        @input="handleInput"
+      />
+      <button
+        type="button"
+        :class="toggleClasses"
+        :aria-label="ariaLabel"
+        @click="toggleVisibility"
+      >
+        <!-- Eye icon (visible state) -->
+        <svg
+          v-if="isVisible"
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+          />
+        </svg>
+        <!-- Eye-off icon (hidden state) -->
+        <svg
+          v-else
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- Add reusable `VsgPasswordInput` component with built-in visibility toggle button
- Update login, password reset, and admin user forms to use the new component
- Include full keyboard accessibility and screen reader support (ARIA labels)

## Changes

- **New:** `VsgPasswordInput.vue` shared component with `auth` and `admin` styling variants
- **Updated:** `LoginForm.vue`, `ResetPasswordForm.vue`, `UserForm.vue` to use the new component

## Testing

- [x] Lint passes
- [x] Production build succeeds
- [x] Manual testing of toggle in all forms (login, reset password, user create/edit)