### PR TITLE
Add automatic image thumbnail generation for uploaded media

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,14 @@ clean:
 	find . -type d -name ".turbo" -prune -exec rm -rf '{}' +
 	find . -type d -name "coverage" -prune -exec rm -rf '{}' +
 	find . -type d -name "generated" -prune -exec rm -rf '{}' +
+	rm ./apps/api/uploads/*.{jpg,jpeg,png,webp,svg}
+
+clean-migrations:
+	rm -rvf apps/api/prisma/migrations
+	pnpm --filter api exec prisma migrate reset
+	pnpm --filter api exec prisma migrate dev --name init
+
+setup:
+	pnpm install
+	pnpm --filter api prisma:generate
+	pnpm --filter api prisma:migrate

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -19,6 +19,9 @@ CORS_ORIGINS="http://localhost:5173"
 # Maximum file size in bytes (default: 10485760 = 10MB)
 # MAX_FILE_SIZE=10485760
 
+# Thumbnail Generation Configuration (optional)
+THUMBNAIL_QUALITY=80
+
 # Password Reset Configuration
 # Base URL for password reset links (required for email links)
 APP_URL="http://localhost:5173"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,6 +34,7 @@
     "@types/passport": "^1.0.17",
     "@types/passport-local": "^1.0.38",
     "@types/pg": "^8.15.6",
+    "@types/sharp": "^0.32.0",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.4",
@@ -73,6 +74,7 @@
     "pg": "^8.16.3",
     "rate-limit-redis": "^4.3.1",
     "rrule": "^2.8.1",
+    "sharp": "^0.34.5",
     "slugify": "^1.6.6",
     "uuid": "^13.0.0"
   }

--- a/apps/api/prisma/migrations/20251230220155_init/migration.sql
+++ b/apps/api/prisma/migrations/20251230220155_init/migration.sql
@@ -135,6 +135,7 @@ CREATE TABLE "Media" (
     "mimetype" TEXT NOT NULL,
     "size" INTEGER NOT NULL,
     "type" TEXT NOT NULL DEFAULT 'IMAGE',
+    "thumbnails" JSONB,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Media {
   mimetype       String
   size           Int
   type           String          @default("IMAGE")
+  thumbnails     Json?
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
   departments    Department[]

--- a/apps/api/src/routes/media.routes.ts
+++ b/apps/api/src/routes/media.routes.ts
@@ -82,4 +82,30 @@ router.delete(
   }),
 );
 
+// Protected route - Regenerate thumbnails for all media (batch)
+// NOTE: This route must be defined before /:id/regenerate-thumbnails to avoid route conflicts
+router.post(
+  '/regenerate-thumbnails',
+  jwtMiddleware,
+  authGuardMiddleware,
+  asyncHandlerMiddleware(async (_req, res) => {
+    const result = await mediaService.regenerateAllThumbnails();
+    res.json(result);
+  }),
+);
+
+// Protected route - Regenerate thumbnails for specific media
+router.post(
+  '/:id/regenerate-thumbnails',
+  jwtMiddleware,
+  authGuardMiddleware,
+  mediaIdParamValidator,
+  validationMiddleware,
+  asyncHandlerMiddleware(async (req, res) => {
+    const id = Number(req.params.id);
+    const media = await mediaService.regenerateThumbnails(id);
+    res.json(media);
+  }),
+);
+
 export { router as mediaRouter };

--- a/apps/api/src/services/thumbnail.service.ts
+++ b/apps/api/src/services/thumbnail.service.ts
@@ -1,0 +1,128 @@
+import fs from 'fs/promises';
+import path from 'path';
+import sharp from 'sharp';
+import { UPLOAD_DIR } from '@/config/upload.config';
+import {
+  ThumbnailConfig,
+  ThumbnailsMap,
+  ThumbnailSize,
+} from '@/types/media.types';
+
+// Thumbnail size configurations
+const THUMBNAIL_SIZES: ThumbnailConfig[] = [
+  { name: 'thumb', width: 150, height: 150 },
+  { name: 'small', width: 300, height: 300 },
+  { name: 'medium', width: 600, height: 600 },
+  { name: 'large', width: 1200, height: 1200 },
+];
+
+// Supported mimetypes for thumbnail generation
+const SUPPORTED_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+// Environment variable configuration
+const THUMBNAIL_QUALITY = parseInt(process.env.THUMBNAIL_QUALITY || '80', 10);
+
+export class ThumbnailService {
+  /**
+   * Check if a mimetype supports thumbnail generation
+   */
+  isSupportedMimetype(mimetype: string): boolean {
+    return SUPPORTED_MIMETYPES.includes(mimetype);
+  }
+
+  /**
+   * Generate thumbnail filename from original filename and size
+   */
+  getThumbnailFilename(originalFilename: string, size: ThumbnailSize): string {
+    const ext = path.extname(originalFilename);
+    const basename = path.basename(originalFilename, ext);
+    return `${basename}-${size}.webp`;
+  }
+
+  /**
+   * Generate all thumbnail sizes for an image
+   * @param inputPath Full path to the source image
+   * @param filename Original filename (used to derive thumbnail names)
+   * @returns ThumbnailsMap with filenames for each size, or null if generation fails
+   */
+  async generateThumbnails(
+    inputPath: string,
+    filename: string,
+  ): Promise<ThumbnailsMap | null> {
+    const thumbnails: ThumbnailsMap = {};
+
+    try {
+      for (const sizeConfig of THUMBNAIL_SIZES) {
+        const thumbnailFilename = this.getThumbnailFilename(
+          filename,
+          sizeConfig.name,
+        );
+        const outputPath = path.join(UPLOAD_DIR, thumbnailFilename);
+
+        await sharp(inputPath)
+          .resize({
+            width: sizeConfig.width,
+            height: sizeConfig.height,
+            fit: 'cover',
+            position: 'center',
+          })
+          .webp({ quality: THUMBNAIL_QUALITY, effort: 4 })
+          .toFile(outputPath);
+
+        thumbnails[sizeConfig.name] = thumbnailFilename;
+      }
+
+      return thumbnails;
+    } catch (error) {
+      console.warn('Failed to generate thumbnails:', error);
+      // Clean up any partially generated thumbnails
+      await this.deleteThumbnails(filename);
+      return null;
+    }
+  }
+
+  /**
+   * Delete all thumbnails for a given original filename
+   * @param filename Original filename (used to derive thumbnail names)
+   */
+  async deleteThumbnails(filename: string): Promise<void> {
+    for (const sizeConfig of THUMBNAIL_SIZES) {
+      const thumbnailFilename = this.getThumbnailFilename(
+        filename,
+        sizeConfig.name,
+      );
+      const thumbnailPath = path.join(UPLOAD_DIR, thumbnailFilename);
+
+      try {
+        await fs.unlink(thumbnailPath);
+      } catch (error) {
+        // Ignore errors if file doesn't exist
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.warn(`Failed to delete thumbnail ${thumbnailPath}:`, error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Delete thumbnails using a ThumbnailsMap (more precise, uses actual stored filenames)
+   * @param thumbnails ThumbnailsMap from the database
+   */
+  async deleteThumbnailsFromMap(thumbnails: ThumbnailsMap): Promise<void> {
+    for (const size of Object.keys(thumbnails) as ThumbnailSize[]) {
+      const thumbnailFilename = thumbnails[size];
+      if (!thumbnailFilename) continue;
+
+      const thumbnailPath = path.join(UPLOAD_DIR, thumbnailFilename);
+
+      try {
+        await fs.unlink(thumbnailPath);
+      } catch (error) {
+        // Ignore errors if file doesn't exist
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.warn(`Failed to delete thumbnail ${thumbnailPath}:`, error);
+        }
+      }
+    }
+  }
+}

--- a/apps/api/src/types/media.types.ts
+++ b/apps/api/src/types/media.types.ts
@@ -7,9 +7,32 @@ export interface CreateMediaDto {
   mimetype: string;
   size: number;
   type?: string;
+  thumbnails?: ThumbnailsMap | null;
 }
 
 export type Media = PrismaMedia;
+
+export type ThumbnailSize = 'thumb' | 'small' | 'medium' | 'large';
+
+export interface ThumbnailsMap {
+  thumb?: string;
+  small?: string;
+  medium?: string;
+  large?: string;
+}
+
+export interface ThumbnailConfig {
+  name: ThumbnailSize;
+  width: number;
+  height: number;
+}
+
+export interface RegenerateThumbnailsResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+}
 
 export interface PaginationMeta {
   total: number;

--- a/apps/web/src/modules/admin/views/MediaLibraryView.vue
+++ b/apps/web/src/modules/admin/views/MediaLibraryView.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { onMounted, computed } from 'vue';
+import { onMounted, computed, ref } from 'vue';
 import { useMediaStore } from '../stores/mediaStore';
+import type { RegenerateThumbnailsResult } from '../stores/mediaStore';
 import MediaUploadZone from '../components/MediaUploadZone.vue';
 import MediaGallery from '../components/MediaGallery.vue';
 
 const mediaStore = useMediaStore();
+
+const showRegenerateConfirm = ref(false);
+const regenerateResult = ref<RegenerateThumbnailsResult | null>(null);
 
 onMounted(() => {
   mediaStore.fetchMedia();
@@ -16,6 +20,23 @@ function handleUploadComplete() {
 
 const mediaCount = computed(() => mediaStore.media.length);
 const totalCount = computed(() => mediaStore.meta?.total ?? 0);
+
+function openRegenerateConfirm() {
+  showRegenerateConfirm.value = true;
+  regenerateResult.value = null;
+}
+
+function closeRegenerateConfirm() {
+  showRegenerateConfirm.value = false;
+  regenerateResult.value = null;
+}
+
+async function executeRegenerateAll() {
+  const result = await mediaStore.regenerateAllThumbnails();
+  if (result) {
+    regenerateResult.value = result;
+  }
+}
 </script>
 
 <template>
@@ -67,12 +88,144 @@ const totalCount = computed(() => mediaStore.meta?.total ?? 0);
         <h2 class="font-display text-xl tracking-wider text-vsg-blue-900">
           GALERIE
         </h2>
-        <span class="font-body text-sm text-gray-500">
-          {{ mediaCount }} von {{ totalCount }} Medien
-        </span>
+        <div class="flex items-center gap-4">
+          <span class="font-body text-sm text-gray-500">
+            {{ mediaCount }} von {{ totalCount }} Medien
+          </span>
+          <button
+            type="button"
+            class="px-4 py-2 bg-vsg-blue-600 text-white font-body text-sm rounded-lg hover:bg-vsg-blue-700 transition-colors flex items-center gap-2"
+            :disabled="mediaStore.isRegenerating || mediaCount === 0"
+            :class="{
+              'opacity-50 cursor-not-allowed':
+                mediaStore.isRegenerating || mediaCount === 0,
+            }"
+            @click="openRegenerateConfirm"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            Alle Thumbnails regenerieren
+          </button>
+        </div>
       </div>
 
       <MediaGallery />
     </div>
+
+    <!-- Regenerate All Confirmation Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showRegenerateConfirm"
+        class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+        @click.self="closeRegenerateConfirm"
+      >
+        <div class="bg-white rounded-xl p-6 max-w-md w-full shadow-xl">
+          <h3
+            class="font-display text-lg tracking-wider text-vsg-blue-900 mb-4"
+          >
+            THUMBNAILS REGENERIEREN
+          </h3>
+
+          <!-- Confirmation State -->
+          <div v-if="!mediaStore.isRegenerating && !regenerateResult">
+            <p class="font-body text-gray-600 mb-6">
+              Mochtest du die Thumbnails fur alle {{ totalCount }} Medien neu
+              generieren? Dieser Vorgang kann einige Zeit dauern.
+            </p>
+            <p class="font-body text-sm text-gray-500 mb-6">
+              SVG-Dateien werden ubersprungen, da sie keine Thumbnails
+              benotigen.
+            </p>
+
+            <div class="flex justify-end gap-3">
+              <button
+                type="button"
+                class="px-4 py-2 border border-gray-300 text-gray-600 font-body text-sm rounded-lg hover:bg-gray-50 transition-colors"
+                @click="closeRegenerateConfirm"
+              >
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                class="px-4 py-2 bg-vsg-blue-600 text-white font-body text-sm rounded-lg hover:bg-vsg-blue-700 transition-colors"
+                @click="executeRegenerateAll"
+              >
+                Regenerieren
+              </button>
+            </div>
+          </div>
+
+          <!-- Loading State -->
+          <div v-else-if="mediaStore.isRegenerating" class="text-center py-8">
+            <div
+              class="w-12 h-12 border-4 border-vsg-blue-200 border-t-vsg-blue-600 rounded-full animate-spin mx-auto mb-4"
+            ></div>
+            <p class="font-body text-gray-600">
+              Thumbnails werden regeneriert...
+            </p>
+            <p class="font-body text-sm text-gray-500 mt-2">
+              Bitte warten, dies kann einige Zeit dauern.
+            </p>
+          </div>
+
+          <!-- Result State -->
+          <div v-else-if="regenerateResult">
+            <div
+              class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6"
+            >
+              <div class="flex items-center gap-2 mb-2">
+                <svg
+                  class="w-5 h-5 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <span class="font-body font-medium text-green-800">
+                  Regenerierung abgeschlossen
+                </span>
+              </div>
+              <div class="font-body text-sm text-green-700 space-y-1">
+                <p>Verarbeitet: {{ regenerateResult.processed }}</p>
+                <p>Erfolgreich: {{ regenerateResult.succeeded }}</p>
+                <p v-if="regenerateResult.failed > 0" class="text-red-600">
+                  Fehlgeschlagen: {{ regenerateResult.failed }}
+                </p>
+                <p v-if="regenerateResult.skipped > 0">
+                  Ubersprungen (SVG): {{ regenerateResult.skipped }}
+                </p>
+              </div>
+            </div>
+
+            <div class="flex justify-end">
+              <button
+                type="button"
+                class="px-4 py-2 bg-vsg-blue-600 text-white font-body text-sm rounded-lg hover:bg-vsg-blue-700 transition-colors"
+                @click="closeRegenerateConfirm"
+              >
+                Schliessen
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>

--- a/apps/web/src/modules/default/components/ContactForm.vue
+++ b/apps/web/src/modules/default/components/ContactForm.vue
@@ -213,8 +213,8 @@ const clearSuccess = () => {
               Anfrage!
             </p>
             <button
-              @click="clearSuccess"
               class="mt-2 text-sm text-green-700 hover:text-green-900 underline font-body"
+              @click="clearSuccess"
             >
               Weitere Nachricht senden
             </button>
@@ -258,7 +258,7 @@ const clearSuccess = () => {
     </Transition>
 
     <!-- Form -->
-    <form v-if="!submitSuccess" @submit.prevent="submitForm" class="space-y-5">
+    <form v-if="!submitSuccess" class="space-y-5" @submit.prevent="submitForm">
       <!-- Honeypot field - hidden from users -->
       <div
         class="absolute"
@@ -267,10 +267,10 @@ const clearSuccess = () => {
       >
         <label for="website">Website (Leave this field blank)</label>
         <input
-          type="text"
           id="website"
-          name="website"
           v-model="website"
+          type="text"
+          name="website"
           tabindex="-1"
           autocomplete="off"
         />

--- a/apps/web/src/modules/default/stores/contactPersonsStore.ts
+++ b/apps/web/src/modules/default/stores/contactPersonsStore.ts
@@ -3,6 +3,13 @@ import { defineStore } from 'pinia';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
+export interface ThumbnailsMap {
+  thumb?: string;
+  small?: string;
+  medium?: string;
+  large?: string;
+}
+
 export interface Media {
   id: number;
   filename: string;
@@ -11,6 +18,7 @@ export interface Media {
   mimetype: string;
   size: number;
   type: string;
+  thumbnails?: ThumbnailsMap | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/web/src/modules/default/views/ContactView.vue
+++ b/apps/web/src/modules/default/views/ContactView.vue
@@ -37,6 +37,13 @@ function getInitials(cp: ContactPerson): string {
 function getProfileImageUrl(cp: ContactPerson): string | null {
   if (!cp.profileImage) return null;
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+
+  // Use 'small' thumbnail (300x300) for profile images if available
+  // Falls back to original if no thumbnails exist
+  if (cp.profileImage.thumbnails?.small) {
+    return `${apiBaseUrl}/uploads/${cp.profileImage.thumbnails.small}`;
+  }
+
   return `${apiBaseUrl}/uploads/${cp.profileImage.filename}`;
 }
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       rrule:
         specifier: ^2.8.1
         version: 2.8.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -117,6 +120,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.6
         version: 8.15.6
+      '@types/sharp':
+        specifier: ^0.32.0
+        version: 0.32.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -475,6 +481,9 @@ packages:
   '@electric-sql/pglite@0.3.2':
     resolution: {integrity: sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==}
 
+  '@emnapi/runtime@1.7.1':
+    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -690,6 +699,143 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/colour@1.0.0':
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
@@ -1282,6 +1428,10 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/sharp@0.32.0':
+    resolution: {integrity: sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==}
+    deprecated: This is a stub types definition. sharp provides its own type definitions, so you do not need this installed.
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -2822,6 +2972,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3855,6 +4009,11 @@ snapshots:
 
   '@electric-sql/pglite@0.3.2': {}
 
+  '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -3993,6 +4152,102 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.0.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.7.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@ioredis/commands@1.4.0': {}
 
@@ -4670,6 +4925,10 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 24.10.1
       '@types/send': 0.17.6
+
+  '@types/sharp@0.32.0':
+    dependencies:
+      sharp: 0.34.5
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -6341,6 +6600,37 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Implements automatic thumbnail generation for uploaded images (JPEG, PNG, WebP) using Sharp. Thumbnails are generated in 4 sizes (thumb 150px, small 300px, medium 600px, large 1200px) as WebP format for optimal file size.

## Changes

### Backend changes:

- New `ThumbnailService` for generating and managing thumbnails
- Thumbnails auto-generated on upload, deleted with media
- New API endpoints for regenerating thumbnails (single and batch)
- Database migration adds `thumbnails` JSON field to Media model
- Graceful failure handling - uploads succeed even if thumbnail generation fails

### Frontend changes:

- Admin UI with "Regenerate All Thumbnails" button and per-item regenerate buttons
- Contact page now uses `small` thumbnail for profile images
- Visual feedback with loading states and result statistics