### PR TITLE
feat(mediathek): allow PDF uploads in the media library

### DIFF
--- a/apps/api/src/config/upload.config.ts
+++ b/apps/api/src/config/upload.config.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { BadRequestException } from '@/errors/http-errors';
 
 // Allowed MIME types for image uploads
-const ALLOWED_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml'];
+const ALLOWED_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'application/pdf'];
 
 // Max file size (default 10MB)
 const MAX_FILE_SIZE = parseInt(process.env.MAX_FILE_SIZE || '10485760', 10);

--- a/apps/api/src/routes/media.routes.ts
+++ b/apps/api/src/routes/media.routes.ts
@@ -62,7 +62,7 @@ router.post(
       path: req.file.filename, // Just the filename, path is constructed from UPLOAD_DIR
       mimetype: req.file.mimetype,
       size: req.file.size,
-      type: 'IMAGE',
+      type: req.file.mimetype === 'application/pdf' ? 'DOCUMENT' : 'IMAGE',
       folderId,
     });
 

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -57,6 +57,7 @@ import {
   faUsers,
   faWrench,
   faXmark,
+  faFilePdf,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -84,6 +85,7 @@ library.add(
   faEye,
   faEyeSlash,
   faFileArrowDown,
+  faFilePdf,
   faFolder,
   faFolderPlus,
   faGrip,
@@ -136,6 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
     `img-src 'self' data: https: ${import.meta.env.VITE_API_BASE_URL};`,
     "font-src 'self' data: https://maxcdn.bootstrapcdn.com;",
     `connect-src 'self' ${import.meta.env.VITE_API_BASE_URL};`,
+    `object-src 'self' ${import.meta.env.VITE_API_BASE_URL};`,
   ].join('; ');
   document.head.appendChild(meta);
 });

--- a/apps/web/src/modules/admin/components/MediaGalleryItem.vue
+++ b/apps/web/src/modules/admin/components/MediaGalleryItem.vue
@@ -25,6 +25,10 @@ function isSvg(item: MediaItem): boolean {
   return item.mimetype === 'image/svg+xml';
 }
 
+function isPdf(item: MediaItem): boolean {
+  return item.mimetype === 'application/pdf';
+}
+
 function getFileExtension(filename: string): string {
   return filename.split('.').pop()?.toUpperCase() || '';
 }
@@ -32,7 +36,21 @@ function getFileExtension(filename: string): string {
 
 <template>
   <div class="group relative bg-white border border-gray-200 rounded-lg overflow-hidden aspect-square">
+    <!-- PDF tile -->
+    <div
+      v-if="isPdf(item)"
+      class="w-full h-full flex flex-col items-center justify-center bg-gray-50 gap-2"
+    >
+      <FontAwesomeIcon
+        icon="file-pdf"
+        class="text-red-500 text-4xl"
+      />
+      <span class="font-body text-xs text-gray-500 px-2 text-center truncate w-full text-center">PDF</span>
+    </div>
+
+    <!-- Image tile -->
     <img
+      v-else
       :src="mediaUrl"
       :alt="item.originalName"
       class="w-full h-full object-cover"

--- a/apps/web/src/modules/admin/components/MediaUploadZone.vue
+++ b/apps/web/src/modules/admin/components/MediaUploadZone.vue
@@ -12,7 +12,7 @@ const mediaStore = useMediaStore();
 const isDragging = ref(false);
 const fileInput = ref<HTMLInputElement | null>(null);
 
-const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml'];
+const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'application/pdf'];
 
 const uploadItems = computed(() => {
   return Array.from(mediaStore.uploadProgress.values());
@@ -59,7 +59,7 @@ async function processFiles(files: File[]) {
 
   if (validFiles.length < files.length) {
     const invalidCount = files.length - validFiles.length;
-    alert(`${invalidCount} Datei(en) wurden ignoriert. Erlaubte Formate: JPG, PNG, WebP, SVG`);
+    alert(`${invalidCount} Datei(en) wurden ignoriert. Erlaubte Formate: JPG, PNG, WebP, SVG, PDF`);
   }
 
   if (validFiles.length > 0) {
@@ -85,7 +85,7 @@ async function processFiles(files: File[]) {
         ref="fileInput"
         type="file"
         class="hidden"
-        accept="image/jpeg,image/png,image/webp,image/svg+xml"
+        accept="image/jpeg,image/png,image/webp,image/svg+xml,application/pdf"
         multiple
         @change="handleFileChange"
       />
@@ -115,7 +115,7 @@ async function processFiles(files: File[]) {
               <span class="text-vsg-blue-600 font-medium">klicken</span>
             </span>
           </p>
-          <p class="font-body text-xs text-gray-400 mt-1">JPG, PNG, WebP, SVG (max. 10MB)</p>
+          <p class="font-body text-xs text-gray-400 mt-1">JPG, PNG, WebP, SVG, PDF (max. 10MB)</p>
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/admin/components/modals/MediaPreviewModal.vue
+++ b/apps/web/src/modules/admin/components/modals/MediaPreviewModal.vue
@@ -17,6 +17,10 @@ function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
+
+function isPdf(item: MediaItem): boolean {
+  return item.mimetype === 'application/pdf';
+}
 </script>
 
 <template>
@@ -26,7 +30,7 @@ function formatFileSize(bytes: number): string {
       class="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
       @click.self="emit('close')"
     >
-      <div class="relative max-w-4xl max-h-full">
+      <div class="relative max-w-4xl w-full max-h-full">
         <button
           type="button"
           class="absolute -top-10 right-0 p-2 text-white hover:text-gray-300 transition-colors"
@@ -35,7 +39,18 @@ function formatFileSize(bytes: number): string {
           <FontAwesomeIcon icon="xmark" />
         </button>
 
+        <!-- PDF preview -->
+        <embed
+          v-if="isPdf(item)"
+          :src="mediaUrl"
+          type="application/pdf"
+          class="w-full rounded-lg"
+          style="height: 80vh"
+        />
+
+        <!-- Image preview -->
         <img
+          v-else
           :src="mediaUrl"
           :alt="item.originalName"
           class="max-w-full max-h-[80vh] object-contain rounded-lg"


### PR DESCRIPTION
Extend the Mediathek to accept application/pdf alongside existing image types. PDFs are stored on disk with type DOCUMENT, displayed as an icon tile in the gallery, and previewed inline via a native <embed> element. Also adds object-src to the CSP to allow the API origin for embed/object resources.