### PR TITLE
feat(web): add public post detail page at /beitrag/:slug

### DIFF
--- a/apps/web/src/modules/default/components/NewsSection.vue
+++ b/apps/web/src/modules/default/components/NewsSection.vue
@@ -110,7 +110,7 @@ const listPosts = computed(() => posts.value.slice(1));
           :date="formatDate(featuredPost.createdAt)"
           :title="featuredPost.title.toUpperCase()"
           :excerpt="getExcerpt(featuredPost.content)"
-          :href="`/news/${featuredPost.slug}`"
+          :href="`/beitrag/${featuredPost.slug}`"
         />
 
         <!-- News List -->
@@ -123,7 +123,7 @@ const listPosts = computed(() => posts.value.slice(1));
             :key="post.id"
             :date="formatDate(post.createdAt)"
             :title="post.title"
-            :href="`/news/${post.slug}`"
+            :href="`/beitrag/${post.slug}`"
           />
         </div>
       </div>

--- a/apps/web/src/modules/default/router/routes.ts
+++ b/apps/web/src/modules/default/router/routes.ts
@@ -60,6 +60,11 @@ const routes: RouteRecordRaw[] = [
         name: 'department-detail',
         component: () => import('../views/DefaultDepartmentView.vue'),
       },
+      {
+        path: 'beitrag/:slug',
+        name: 'post-detail',
+        component: () => import('../views/DefaultPostView.vue'),
+      },
     ],
   },
 ];

--- a/apps/web/src/modules/default/views/DefaultPostView.vue
+++ b/apps/web/src/modules/default/views/DefaultPostView.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { watch, onMounted, onUnmounted, watchEffect } from 'vue';
+import { useRoute } from 'vue-router';
+import { storeToRefs } from 'pinia';
+import { useDefaultPostsStore } from '../stores/postsStore';
+import VsgApiState from '@/shared/components/VsgApiState.vue';
+import VsgHeroSection from '../components/VsgHeroSection.vue';
+import VsgContentSection from '../components/VsgContentSection.vue';
+
+const route = useRoute();
+const postsStore = useDefaultPostsStore();
+const { currentPost, currentPostLoading, currentPostError, currentPostNotFound } = storeToRefs(postsStore);
+
+function fetchPost() {
+  const slug = route.params.slug as string;
+  if (slug) {
+    postsStore.fetchPostBySlug(slug);
+  }
+}
+
+// Fetch on mount
+onMounted(() => {
+  fetchPost();
+});
+
+// Re-fetch when slug changes without a full page reload
+watch(
+  () => route.params.slug,
+  () => {
+    fetchPost();
+  },
+);
+
+// Set dynamic page title
+watchEffect(() => {
+  if (currentPost.value) {
+    document.title = `${currentPost.value.title} | VSG Kugelberg`;
+  } else if (currentPostNotFound.value) {
+    document.title = 'Beitrag nicht gefunden | VSG Kugelberg';
+  } else {
+    document.title = 'Beitrag | VSG Kugelberg';
+  }
+});
+
+// Clear state on unmount
+onUnmounted(() => {
+  postsStore.clearCurrentPost();
+});
+</script>
+
+<template>
+  <div class="min-h-screen text-white overflow-x-hidden selection:bg-vsg-gold-500 selection:text-vsg-blue-900">
+    <VsgApiState
+      :is-loading="currentPostLoading"
+      :error="currentPostError"
+      :empty="!currentPost"
+      empty-message="Beitrag nicht gefunden"
+    >
+      <!-- Hero Section -->
+      <VsgHeroSection
+        :headline="currentPost!.title.toUpperCase()"
+        min-height="70vh"
+      />
+
+      <!-- Content Section -->
+      <VsgContentSection v-if="currentPost!.content">
+        <div
+          class="prose prose-lg max-w-none font-body text-vsg-blue-700"
+          v-html="currentPost!.content"
+        />
+      </VsgContentSection>
+    </VsgApiState>
+  </div>
+</template>


### PR DESCRIPTION
Introduce a dynamic route and view for reading published posts, following the same hero + content section layout used by the Datenschutz and Impressum pages. Extends postsStore with single-post state and fetchPostBySlug, and fixes the previously dead /news/<slug> links in NewsSection to point to /beitrag/<slug>.