### PR TITLE
feat: add welcome text section to homepage and department pages

### DIFF
--- a/apps/api/prisma/migrations/20260303121746_init/migration.sql
+++ b/apps/api/prisma/migrations/20260303121746_init/migration.sql
@@ -58,6 +58,7 @@ CREATE TABLE "Department" (
     "name" TEXT NOT NULL,
     "slug" TEXT NOT NULL,
     "shortDescription" TEXT NOT NULL,
+    "welcomeText" TEXT,
     "iconId" INTEGER,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
@@ -273,6 +274,7 @@ CREATE TABLE "HomepageContent" (
     "postsCount" INTEGER NOT NULL DEFAULT 5,
     "ctaHeadline" TEXT NOT NULL,
     "ctaDescription" TEXT NOT NULL,
+    "welcomeText" TEXT,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "HomepageContent_pkey" PRIMARY KEY ("id")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Department {
   name             String                    @unique
   slug             String                    @unique
   shortDescription String
+  welcomeText      String?
   iconId           Int?
   icon             Media?                    @relation(fields: [iconId], references: [id], onDelete: SetNull)
   stats            DepartmentStat[]
@@ -318,6 +319,7 @@ model HomepageContent {
   postsCount            Int            @default(5)
   ctaHeadline           String
   ctaDescription        String
+  welcomeText           String?
   updatedAt             DateTime       @updatedAt
 }
 

--- a/apps/api/src/services/departments.service.ts
+++ b/apps/api/src/services/departments.service.ts
@@ -101,6 +101,7 @@ export class DepartmentsService {
           name: createDepartmentDto.name,
           slug,
           shortDescription: createDepartmentDto.shortDescription,
+          welcomeText: createDepartmentDto.welcomeText ?? null,
           iconId: createDepartmentDto.iconId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -141,6 +142,10 @@ export class DepartmentsService {
 
     if (updateDepartmentDto.shortDescription !== undefined) {
       updateData.shortDescription = updateDepartmentDto.shortDescription;
+    }
+
+    if (updateDepartmentDto.welcomeText !== undefined) {
+      updateData.welcomeText = updateDepartmentDto.welcomeText;
     }
 
     // Handle iconId: can be set to a value, or explicitly set to null to remove

--- a/apps/api/src/services/homepage-content.service.ts
+++ b/apps/api/src/services/homepage-content.service.ts
@@ -44,6 +44,7 @@ export class HomepageContentService {
       postsCount: content.postsCount,
       ctaHeadline: content.ctaHeadline,
       ctaDescription: content.ctaDescription,
+      welcomeText: content.welcomeText,
       updatedAt: content.updatedAt,
     };
   }
@@ -68,6 +69,7 @@ export class HomepageContentService {
           postsCount: data.postsCount,
           ctaHeadline: data.ctaHeadline,
           ctaDescription: data.ctaDescription,
+          welcomeText: data.welcomeText,
         },
         create: {
           id: 1,
@@ -82,6 +84,7 @@ export class HomepageContentService {
           postsCount: data.postsCount ?? 5,
           ctaHeadline: data.ctaHeadline ?? '',
           ctaDescription: data.ctaDescription ?? '',
+          welcomeText: data.welcomeText ?? null,
         },
       });
 

--- a/apps/api/src/types/department.types.ts
+++ b/apps/api/src/types/department.types.ts
@@ -4,12 +4,14 @@ import { Media } from './media.types';
 export interface CreateDepartmentDto {
   name: string;
   shortDescription: string;
+  welcomeText?: string | null;
   iconId?: number;
 }
 
 export interface UpdateDepartmentDto {
   name?: string;
   shortDescription?: string;
+  welcomeText?: string | null;
   iconId?: number | null;
 }
 

--- a/apps/api/src/types/homepage-content.types.ts
+++ b/apps/api/src/types/homepage-content.types.ts
@@ -25,6 +25,7 @@ export interface HomepageContent {
   postsCount: number;
   ctaHeadline: string;
   ctaDescription: string;
+  welcomeText: string | null;
   updatedAt: Date;
 }
 

--- a/apps/api/src/validators/department.validators.ts
+++ b/apps/api/src/validators/department.validators.ts
@@ -16,6 +16,14 @@ export const createDepartmentValidator = [
     .withMessage('Short description must be between 10 and 5000 characters'),
 
   body('iconId').optional().isInt({ min: 1 }).withMessage('Icon ID must be a positive integer'),
+
+  body('welcomeText')
+    .optional({ nullable: true })
+    .custom((value) => {
+      if (value === null) return true;
+      if (typeof value === 'string') return true;
+      throw new Error('Welcome text must be a string or null');
+    }),
 ];
 
 export const updateDepartmentValidator = [
@@ -29,6 +37,14 @@ export const updateDepartmentValidator = [
       if (value === null) return true;
       if (Number.isInteger(value) && value >= 1) return true;
       throw new Error('Icon ID must be a positive integer or null');
+    }),
+
+  body('welcomeText')
+    .optional({ nullable: true })
+    .custom((value) => {
+      if (value === null) return true;
+      if (typeof value === 'string') return true;
+      throw new Error('Welcome text must be a string or null');
     }),
 ];
 

--- a/apps/api/src/validators/homepage-content.validators.ts
+++ b/apps/api/src/validators/homepage-content.validators.ts
@@ -16,6 +16,8 @@ export const updateHomepageContentValidator = [
   body('ctaHeadline').optional().isString().trim(),
   body('ctaDescription').optional().isString().trim(),
 
+  body('welcomeText').optional({ nullable: true }).isString().trim(),
+
   body('stats').optional().isArray(),
   body('stats.*.label').isString().trim().notEmpty(),
   body('stats.*.value').isString().trim().notEmpty(),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/free-regular-svg-icons": "^7.1.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/vue-fontawesome": "^3.1.3",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "chart.js": "^4.5.1",
     "easymde": "^2.20.0",

--- a/apps/web/src/modules/admin/components/forms/DepartmentWelcomeForm.vue
+++ b/apps/web/src/modules/admin/components/forms/DepartmentWelcomeForm.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useDepartmentsStore } from '../../stores/departmentsStore';
+import type { DepartmentExtended } from '../../types/department-extended.types';
+import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
+import AdminButton from '../AdminButton.vue';
+
+const props = defineProps<{
+  department: DepartmentExtended;
+}>();
+
+const departmentsStore = useDepartmentsStore();
+
+const welcomeText = ref('');
+
+watch(
+  () => props.department,
+  (newDepartment) => {
+    if (newDepartment) {
+      welcomeText.value = newDepartment.welcomeText ?? '';
+    }
+  },
+  { immediate: true },
+);
+
+async function handleSubmit() {
+  await departmentsStore.updateDepartment(props.department.slug, {
+    welcomeText: welcomeText.value || null,
+  });
+}
+</script>
+
+<template>
+  <form
+    class="space-y-6"
+    @submit.prevent="handleSubmit"
+  >
+    <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+      <h2 class="font-display text-xl tracking-wider text-vsg-blue-900 mb-6 uppercase">Willkommenstext</h2>
+
+      <div class="space-y-6">
+        <div>
+          <label
+            for="welcomeText"
+            class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
+          >
+            Begrüßungstext
+          </label>
+          <VsgMarkdownEditor
+            id="welcomeText"
+            v-model="welcomeText"
+            placeholder="Willkommenstext für die Abteilungsseite..."
+            min-height="200px"
+          />
+          <p class="mt-2 text-xs text-gray-500">
+            Dieser Text wird auf der Abteilungsseite zwischen dem Hero-Bereich und den Statistiken angezeigt. Lassen Sie das Feld leer, um den Bereich
+            auszublenden.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end">
+      <AdminButton
+        type="submit"
+        size="large"
+        :disabled="departmentsStore.isLoading"
+        :loading="departmentsStore.isLoading"
+      >
+        {{ departmentsStore.isLoading ? 'Speichern...' : 'Speichern' }}
+      </AdminButton>
+    </div>
+  </form>
+</template>

--- a/apps/web/src/modules/admin/components/forms/HomepageWelcomeForm.vue
+++ b/apps/web/src/modules/admin/components/forms/HomepageWelcomeForm.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useHomepageContentStore } from '../../stores/homepageContentStore';
+import type { HomepageContent } from '../../types/homepage-content.types';
+import VsgMarkdownEditor from '@/shared/components/VsgMarkdownEditor.vue';
+import AdminButton from '../AdminButton.vue';
+
+const props = defineProps<{
+  homepageContent: HomepageContent;
+}>();
+
+const homepageContentStore = useHomepageContentStore();
+
+const welcomeText = ref('');
+
+watch(
+  () => props.homepageContent,
+  (newContent) => {
+    if (newContent) {
+      welcomeText.value = newContent.welcomeText ?? '';
+    }
+  },
+  { immediate: true },
+);
+
+async function handleSubmit() {
+  await homepageContentStore.updateHomepageContent({
+    welcomeText: welcomeText.value || null,
+  });
+}
+</script>
+
+<template>
+  <form
+    class="space-y-6"
+    @submit.prevent="handleSubmit"
+  >
+    <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+      <h2 class="font-display text-xl tracking-wider text-vsg-blue-900 mb-6 uppercase">Willkommenstext</h2>
+
+      <div class="space-y-6">
+        <div>
+          <label
+            for="welcomeText"
+            class="block font-body font-normal text-xs tracking-wider text-vsg-blue-600 uppercase mb-2"
+          >
+            Begrüßungstext
+          </label>
+          <VsgMarkdownEditor
+            id="welcomeText"
+            v-model="welcomeText"
+            placeholder="Willkommenstext für die Startseite..."
+            min-height="200px"
+          />
+          <p class="mt-2 text-xs text-gray-500">
+            Dieser Text wird auf der Startseite zwischen dem Hero-Bereich und den Statistiken angezeigt. Lassen Sie das Feld leer, um den Bereich
+            auszublenden.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end">
+      <AdminButton
+        type="submit"
+        size="large"
+        :disabled="homepageContentStore.isSaving"
+        :loading="homepageContentStore.isSaving"
+      >
+        {{ homepageContentStore.isSaving ? 'Speichern...' : 'Speichern' }}
+      </AdminButton>
+    </div>
+  </form>
+</template>

--- a/apps/web/src/modules/admin/stores/departmentsStore.ts
+++ b/apps/web/src/modules/admin/stores/departmentsStore.ts
@@ -27,6 +27,7 @@ export interface CreateDepartmentData {
 export interface UpdateDepartmentData {
   name?: string;
   shortDescription?: string;
+  welcomeText?: string | null;
   iconId?: number | null;
 }
 

--- a/apps/web/src/modules/admin/types/department-extended.types.ts
+++ b/apps/web/src/modules/admin/types/department-extended.types.ts
@@ -185,6 +185,7 @@ export interface DepartmentExtended {
   name: string;
   slug: string;
   shortDescription: string;
+  welcomeText: string | null;
   iconId: number | null;
   icon: ContactPersonMedia | null;
   stats: DepartmentStat[];

--- a/apps/web/src/modules/admin/types/homepage-content.types.ts
+++ b/apps/web/src/modules/admin/types/homepage-content.types.ts
@@ -31,6 +31,7 @@ export interface HomepageContent {
   postsCount: number;
   ctaHeadline: string;
   ctaDescription: string;
+  welcomeText: string | null;
   updatedAt: string;
 }
 

--- a/apps/web/src/modules/admin/views/AdminDepartmentFormView.vue
+++ b/apps/web/src/modules/admin/views/AdminDepartmentFormView.vue
@@ -7,6 +7,7 @@ import { useDepartmentTrainingStore } from '../stores/departmentTrainingStore';
 import { useDepartmentLocationsStore } from '../stores/departmentLocationsStore';
 import { useDepartmentTrainersStore } from '../stores/departmentTrainersStore';
 import DepartmentForm from '../components/forms/DepartmentForm.vue';
+import DepartmentWelcomeForm from '../components/forms/DepartmentWelcomeForm.vue';
 import VsgTabNav, { type TabDefinition } from '@/shared/components/VsgTabNav.vue';
 import DepartmentStatsEditor from '../components/DepartmentStatsEditor.vue';
 import DepartmentTrainingEditor from '../components/DepartmentTrainingEditor.vue';
@@ -59,6 +60,12 @@ const tabs = computed<TabDefinition[]>(() => {
     {
       id: 'trainer',
       label: 'TRAINER',
+      disabled: disabledInCreateMode,
+      disabledTooltip,
+    },
+    {
+      id: 'willkommen',
+      label: 'WILLKOMMEN',
       disabled: disabledInCreateMode,
       disabledTooltip,
     },
@@ -199,6 +206,14 @@ async function handleDepartmentSaved(savedDepartment: DepartmentExtended) {
               :initial-trainers="department.trainers || []"
             />
           </div>
+        </div>
+
+        <!-- Tab 6: Willkommen -->
+        <div v-show="activeTab === 'willkommen'">
+          <DepartmentWelcomeForm
+            v-if="department"
+            :department="department"
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/admin/views/AdminHomepageView.vue
+++ b/apps/web/src/modules/admin/views/AdminHomepageView.vue
@@ -7,6 +7,7 @@ import HomepageStatsForm from '../components/forms/HomepageStatsForm.vue';
 import HomepageDepartmentsForm from '../components/forms/HomepageDepartmentsForm.vue';
 import HomepagePostsForm from '../components/forms/HomepagePostsForm.vue';
 import HomepageCtaForm from '../components/forms/HomepageCtaForm.vue';
+import HomepageWelcomeForm from '../components/forms/HomepageWelcomeForm.vue';
 import { VsgAlert } from '@/shared/components';
 import AdminPageHeader from '../components/AdminPageHeader.vue';
 import AdminLoadingState from '../components/AdminLoadingState.vue';
@@ -21,6 +22,7 @@ const tabs = computed<TabDefinition[]>(() => [
   { id: 'departments', label: 'Abteilungen' },
   { id: 'posts', label: 'Beiträge' },
   { id: 'cta', label: 'CTA' },
+  { id: 'welcome', label: 'Willkommen' },
 ]);
 
 onMounted(async () => {
@@ -81,6 +83,9 @@ onMounted(async () => {
         </div>
         <div v-show="activeTab === 'cta'">
           <HomepageCtaForm :homepage-content="homepageContentStore.homepageContent" />
+        </div>
+        <div v-show="activeTab === 'welcome'">
+          <HomepageWelcomeForm :homepage-content="homepageContentStore.homepageContent" />
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/default/components/WelcomeSection.vue
+++ b/apps/web/src/modules/default/components/WelcomeSection.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { marked } from 'marked';
+
+interface Props {
+  welcomeText: string;
+}
+
+const props = defineProps<Props>();
+
+const renderedHtml = computed(() => marked(props.welcomeText));
+</script>
+
+<template>
+  <section class="bg-white py-20">
+    <div class="mx-auto max-w-3xl px-6">
+      <!-- Top gold divider -->
+      <div class="flex items-center gap-4 mb-10">
+        <div class="flex-1 h-px bg-vsg-gold-400"></div>
+        <div class="flex gap-1.5">
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-400"></span>
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-500"></span>
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-400"></span>
+        </div>
+        <div class="flex-1 h-px bg-vsg-gold-400"></div>
+      </div>
+
+      <div
+        class="prose prose-lg mx-auto max-w-none text-center prose-headings:font-display prose-headings:text-vsg-blue-900 prose-p:font-body prose-p:text-gray-700 prose-a:text-vsg-blue-600 prose-a:no-underline hover:prose-a:text-vsg-gold-500 prose-strong:text-vsg-blue-900 prose-li:text-gray-700"
+        v-html="renderedHtml"
+      />
+
+      <!-- Bottom gold divider -->
+      <div class="flex items-center gap-4 mt-10">
+        <div class="flex-1 h-px bg-vsg-gold-400"></div>
+        <div class="flex gap-1.5">
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-400"></span>
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-500"></span>
+          <span class="block w-1.5 h-1.5 rounded-full bg-vsg-gold-400"></span>
+        </div>
+        <div class="flex-1 h-px bg-vsg-gold-400"></div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/web/src/modules/default/stores/departmentsStore.ts
+++ b/apps/web/src/modules/default/stores/departmentsStore.ts
@@ -91,6 +91,7 @@ export interface Department {
   name: string;
   slug: string;
   shortDescription: string;
+  welcomeText: string | null;
   iconId: number | null;
   icon: MediaItem | null;
   stats: DepartmentStat[];

--- a/apps/web/src/modules/default/views/DefaultDepartmentView.vue
+++ b/apps/web/src/modules/default/views/DefaultDepartmentView.vue
@@ -12,6 +12,7 @@ import VsgLocationSection from '../components/VsgLocationSection.vue';
 import NewsSection from '../components/NewsSection.vue';
 import VsgTrainersSection from '../components/VsgTrainersSection.vue';
 import VsgDepartmentCtaSection from '../components/VsgDepartmentCtaSection.vue';
+import WelcomeSection from '../components/WelcomeSection.vue';
 import type { Stat, TrainingGroup, DepartmentLocation, Trainer, DepartmentCta } from '../types/department-detail.types';
 
 const route = useRoute();
@@ -158,6 +159,12 @@ const departmentCta = computed<DepartmentCta>(() => {
         :secondary-cta-label="departmentLocations.length > 0 ? 'UNSERE STANDORTE' : undefined"
         :secondary-cta-anchor="departmentLocations.length > 0 ? '#standorte' : undefined"
         min-height="70vh"
+      />
+
+      <!-- Stats Section -->
+      <WelcomeSection
+        v-if="currentDepartment!.welcomeText"
+        :welcome-text="currentDepartment!.welcomeText"
       />
 
       <!-- Stats Section -->

--- a/apps/web/src/modules/default/views/DefaultHomeView.vue
+++ b/apps/web/src/modules/default/views/DefaultHomeView.vue
@@ -2,6 +2,7 @@
 import { onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import VsgHeroSection from '../components/VsgHeroSection.vue';
+import WelcomeSection from '../components/WelcomeSection.vue';
 import StatsSection from '../components/StatsSection.vue';
 import DepartmentsSection from '../components/DepartmentsSection.vue';
 import NewsSection from '../components/NewsSection.vue';
@@ -23,6 +24,11 @@ onMounted(() => {
       :logo="homepageContent?.heroLogo ?? null"
       min-height="screen"
       :show-scroll-indicator="true"
+    />
+
+    <WelcomeSection
+      v-if="homepageContent?.welcomeText"
+      :welcome-text="homepageContent.welcomeText"
     />
 
     <StatsSection :stats="homepageContent?.stats" />

--- a/apps/web/src/shared/types/homepage-content.types.ts
+++ b/apps/web/src/shared/types/homepage-content.types.ts
@@ -24,5 +24,6 @@ export interface HomepageContent {
   postsCount: number;
   ctaHeadline: string;
   ctaDescription: string;
+  welcomeText: string | null;
   updatedAt: string;
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 /* Self-hosted Fonts */
 /* Bebas Neue - Display font */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@fortawesome/vue-fontawesome':
         specifier: ^3.1.3
         version: 3.1.3(@fortawesome/fontawesome-svg-core@7.1.0)(vue@3.5.25(typescript@5.9.3))
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6))
@@ -1497,6 +1500,11 @@ packages:
     resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
@@ -2062,6 +2070,11 @@ packages:
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssstyle@5.3.3:
     resolution: {integrity: sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==}
@@ -3145,6 +3158,10 @@ packages:
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
     engines: {node: '>=12'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -5301,6 +5318,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.18
+
   '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6))':
     dependencies:
       '@tailwindcss/node': 4.1.18
@@ -5987,6 +6009,8 @@ snapshots:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
     optional: true
+
+  cssesc@3.0.0: {}
 
   cssstyle@5.3.3:
     dependencies:
@@ -7079,6 +7103,11 @@ snapshots:
   plimit-lit@1.6.1:
     dependencies:
       queue-lit: 1.5.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.5.6:
     dependencies:


### PR DESCRIPTION
Add optional Markdown-rendered welcome section to both the homepage and department detail pages. Includes database migration, API validation, admin "Willkommen" tab with Markdown editor, and conditional rendering of the new WelcomeSection component between the hero and stats sections.