### PR TITLE
feat(migration): enhance post migration logic and update data handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,10 @@ clean-migrations:
 	DATABASE_URL="postgresql://user:secret@localhost:5432/database_test?schema=public" pnpm --filter api exec prisma migrate reset
 	DATABASE_URL="postgresql://user:secret@localhost:5432/database_test?schema=public" pnpm --filter api prisma:migrate
 	pnpm --filter migrate migrate
+
+migrate:
+	pnpm --filter api prisma:generate
+	pnpm --filter api exec prisma migrate reset
+	DATABASE_URL="postgresql://user:secret@localhost:5432/database_test?schema=public" pnpm --filter api exec prisma migrate reset
+	DATABASE_URL="postgresql://user:secret@localhost:5432/database_test?schema=public" pnpm --filter api prisma:migrate
+	pnpm --filter migrate migrate

--- a/tools/migrate/src/migrators/post-migrator.ts
+++ b/tools/migrate/src/migrators/post-migrator.ts
@@ -28,8 +28,8 @@ export async function migratePosts(
         continue;
       }
 
-      // Filter posts for this category
-      const posts = allPosts.filter(post => post.catid === category.id);
+      // Filter posts for this category (exclude posts with no catid)
+      const posts = allPosts.filter(post => post.catid != null && post.catid === category.id);
 
       if (posts.length === 0) {
         continue;
@@ -57,9 +57,21 @@ export async function migratePosts(
         );
 
         if (result.rows.length > 0) {
+          const newPostId: number = result.rows[0].id;
+          await pgClient.query(
+            `INSERT INTO "_CategoryToPost" ("A", "B") VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+            [pgCategoryId, newPostId],
+          );
           totalPosts++;
+        } else {
+          logger.warning(`Skipped duplicate slug post: "${post.title}" (slug="${slug}")`);
         }
       }
+    }
+
+    const uncategorizedPosts = allPosts.filter(post => post.catid == null);
+    for (const post of uncategorizedPosts) {
+      logger.warning(`Skipped post with no category: "${post.title}"`);
     }
 
     spinner.succeed(`Migrated ${totalPosts} posts`);

--- a/tools/migrate/src/types/joomla.ts
+++ b/tools/migrate/src/types/joomla.ts
@@ -12,7 +12,7 @@ export interface JoomlaPost {
   id: number;
   title: string;
   content: string | null;
-  catid: number;
+  catid: number | null;
   hits: number;
   created: Date;
   modified: Date;

--- a/tools/migrate/src/utils/data-loader.ts
+++ b/tools/migrate/src/utils/data-loader.ts
@@ -82,7 +82,7 @@ export async function loadPostsData(): Promise<JoomlaPost[]> {
       id: Number(row.id),
       title: row.title as string,
       content: (row.content as string | null) ?? null,
-      catid: Number(row.catid),
+      catid: row.catid != null && row.catid !== '' ? Number(row.catid) : null,
       hits: Number(row.hits),
       created: new Date(row.created as string),
       modified: new Date(row.modified as string),


### PR DESCRIPTION
- Refactor post migration to exclude posts without a category ID and log warnings for skipped posts.
- Update JoomlaPost type to allow catid to be null.
- Modify data loading to handle potential null values for catid, ensuring robust data integrity during migration.
- Introduce a new Makefile target for migration to streamline the migration process.